### PR TITLE
chore(deps): bump pawnote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "lottie-react-native": "^6.7.0",
         "lucide-react-native": "^0.378.0",
         "pawdirecte": "^1.0.6",
-        "pawnote": "^1.0.1",
+        "pawnote": "^1.0.2",
         "pawrd": "^0.4.0",
         "react": "18.2.0",
         "react-native": "^0.74.3",
@@ -14431,9 +14431,10 @@
       }
     },
     "node_modules/pawnote": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pawnote/-/pawnote-1.0.1.tgz",
-      "integrity": "sha512-OMkKFp4P3uNHwp0PSQTaY6Oq1XKEQX4QWwDF8VGta8/H9VKmuF/estMCbclLgHVQT3C8IwW/WLgwHxxGJrxIBg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pawnote/-/pawnote-1.0.2.tgz",
+      "integrity": "sha512-1dsd5TCb2c9B3Z28eeBC5wjPzu2kXD6BH7ZefTBNJACsTLiv/1P1jOb1X04G+S/OsoiCbEKAhwTX/ybqlJOxJQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@literate.ink/utilities": "1.0.0-10479345192.1",
         "html-entities": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lottie-react-native": "^6.7.0",
     "lucide-react-native": "^0.378.0",
     "pawdirecte": "^1.0.6",
-    "pawnote": "^1.0.1",
+    "pawnote": "^1.0.2",
     "pawrd": "^0.4.0",
     "react": "18.2.0",
     "react-native": "^0.74.3",


### PR DESCRIPTION
Bump de Pawnote à la dernière version.

Répare un problème lors de l'authentification avec PRONOTE quand l'instance contient des onglets qui n'ont pas de période par défaut.
