### PR TITLE
fix(services): Add username for Turboself in subtitle & account info

### DIFF
--- a/src/stores/account/types.ts
+++ b/src/stores/account/types.ts
@@ -109,6 +109,7 @@ export interface EcoleDirecteAccount extends BaseAccount {
 export interface TurboselfAccount extends BaseExternalAccount {
   service: AccountService.Turboself
   instance: undefined
+  username: string
   authentication: {
     auth: TSAuthentication
     session: TSSession
@@ -118,6 +119,7 @@ export interface TurboselfAccount extends BaseExternalAccount {
 export interface ARDAccount extends BaseExternalAccount {
   service: AccountService.ARD
   instance?: ARDClient
+  username: string
   authentication: {
     pid: string
     username: string

--- a/src/stores/account/types.ts
+++ b/src/stores/account/types.ts
@@ -84,7 +84,7 @@ interface BaseAccount {
 interface BaseExternalAccount {
   localID: string
   isExternal: true
-
+  username: string
   data: Record<string, unknown>
 }
 
@@ -109,7 +109,6 @@ export interface EcoleDirecteAccount extends BaseAccount {
 export interface TurboselfAccount extends BaseExternalAccount {
   service: AccountService.Turboself
   instance: undefined
-  username: string
   authentication: {
     auth: TSAuthentication
     session: TSSession
@@ -119,7 +118,6 @@ export interface TurboselfAccount extends BaseExternalAccount {
 export interface ARDAccount extends BaseExternalAccount {
   service: AccountService.ARD
   instance?: ARDClient
-  username: string
   authentication: {
     pid: string
     username: string

--- a/src/views/settings/ExternalAccount/ARD.tsx
+++ b/src/views/settings/ExternalAccount/ARD.tsx
@@ -23,6 +23,7 @@ const ExternalArdLogin: Screen<"ExternalArdLogin"> = ({ navigation }) => {
       const new_account: ARDAccount = {
         instance: client,
         service: AccountService.ARD,
+        username,
         authentication: {
           schoolID,
           username,

--- a/src/views/settings/ExternalAccount/Turboself.tsx
+++ b/src/views/settings/ExternalAccount/Turboself.tsx
@@ -27,6 +27,7 @@ const ExternalTurboselfLogin: Screen<"ExternalTurboselfLogin"> = ({ navigation }
       const new_account: TurboselfAccount = {
         instance: undefined,
         service: AccountService.Turboself,
+        username,
         authentication: {
           auth, session
         },

--- a/src/views/settings/SettingsExternalServices.tsx
+++ b/src/views/settings/SettingsExternalServices.tsx
@@ -43,7 +43,7 @@ const SettingsExternalServices: Screen<"SettingsExternalServices"> = ({
 
   const showAccountInfo = (account: any) => {
     let info = `Service: ${getServiceName(account.service)}\n`;
-    info += `ID: ${account.authentication.auth.username || account.authentication.username || "N. not"}\n`;
+    info += `ID: ${account.username || "N. not"}\n`;
     info += `School ID: ${account.authentication.schoolID || "N. not"}\n`;
 
 
@@ -130,9 +130,7 @@ const SettingsExternalServices: Screen<"SettingsExternalServices"> = ({
                 <View>
                   <NativeText variant="title">{getServiceName(account.service)}</NativeText>
                   <NativeText variant="subtitle">
-                    {account.isExternal 
-                      ? (account.authentication.username ?? account.authentication.auth.username) 
-                      : `${account.studentName?.first} ${account.studentName?.last}`}
+                    {account.isExternal ? account.username : `${account.studentName?.first} ${account.studentName?.last}`}
                   </NativeText>
                 </View>
               </NativeItem>

--- a/src/views/settings/SettingsExternalServices.tsx
+++ b/src/views/settings/SettingsExternalServices.tsx
@@ -43,7 +43,7 @@ const SettingsExternalServices: Screen<"SettingsExternalServices"> = ({
 
   const showAccountInfo = (account: any) => {
     let info = `Service: ${getServiceName(account.service)}\n`;
-    info += `ID: ${account.authentication.username}\n`;
+    info += `ID: ${account.authentication.auth.username || account.authentication.username || "N. not"}\n`;
     info += `School ID: ${account.authentication.schoolID || "N. not"}\n`;
 
 
@@ -130,7 +130,9 @@ const SettingsExternalServices: Screen<"SettingsExternalServices"> = ({
                 <View>
                   <NativeText variant="title">{getServiceName(account.service)}</NativeText>
                   <NativeText variant="subtitle">
-                    {account.isExternal ? account.authentication.username : `${account.studentName?.first} ${account.studentName?.last}`}
+                    {account.isExternal 
+                      ? (account.authentication.username ?? account.authentication.auth.username) 
+                      : `${account.studentName?.first} ${account.studentName?.last}`}
                   </NativeText>
                 </View>
               </NativeItem>


### PR DESCRIPTION
name: Fix du "undefined" dans Informations du compte et ajout du nom d'utilisateur dans le sous titre du compte externe pour Turboself
description: Quand on ajoute un compte externe, il apparait dans la liste des comptes externes mais le sous titre n'apparait pas et ça fait un espace blanc, quand on clique sur le compte, l'ID est mis en undefined, cette PR est la pour fix ce problème.

Voici des images du fix proposé:
![image](https://github.com/user-attachments/assets/eaba71c3-a2ea-4375-ad3f-f985155449ea)
![image](https://github.com/user-attachments/assets/3a72d4c3-25ed-4ec7-98e3-6a3b9c19855c)
Avant:
![image](https://github.com/user-attachments/assets/4769817e-3043-4096-b118-75fb897041a8)
![image](https://github.com/user-attachments/assets/c88ad5d3-8440-402b-aa9d-c51b4a33f422)
