### PR TITLE
Ajout d'une alerte lors de la connexion a une instance de demo

### DIFF
--- a/src/services/pronote/determinate-authentication-view.tsx
+++ b/src/services/pronote/determinate-authentication-view.tsx
@@ -1,6 +1,6 @@
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { RouteParameters } from "@/router/helpers/types";
-import { KeyRound, LockKeyhole } from "lucide-react-native";
+import { Check, KeyRound, LockKeyhole } from "lucide-react-native";
 import pronote from "pawnote";
 import {info} from "@/utils/logger/logger";
 
@@ -50,7 +50,20 @@ const determinateAuthenticationView = async <ScreenName extends keyof RouteParam
   });
 
   info(JSON.stringify(instance, null, 2), (new Error()).stack!);
-
+  if(pronoteURL.includes("demo.index-education.net")) {
+    showAlert({
+      title: "Instance non supporté",
+      message: "Désolé, les instances de démonstration ne sont pas supportées, elles peuvent être instables ou ne pas fonctionner correctement.",
+      actions: [
+        {
+          title: "Continuer quand même",
+          icon: <Check />,
+          primary: true,
+          backgroundColor: "#BE0B00",
+        },
+      ]
+    });
+  } 
   if (instance.casToken && instance.casURL) {
     showAlert({
       title: `L'instance ${instance.name} nécessite une connexion ENT.`,

--- a/src/services/pronote/determinate-authentication-view.tsx
+++ b/src/services/pronote/determinate-authentication-view.tsx
@@ -52,7 +52,7 @@ const determinateAuthenticationView = async <ScreenName extends keyof RouteParam
   info(JSON.stringify(instance, null, 2), (new Error()).stack!);
   if(pronoteURL.includes("demo.index-education.net")) {
     showAlert({
-      title: "Instance non supporté",
+      title: "Instance non supportée",
       message: "Désolé, les instances de démonstration ne sont pas supportées, elles peuvent être instables ou ne pas fonctionner correctement.",
       actions: [
         {

--- a/src/services/pronote/determinate-authentication-view.tsx
+++ b/src/services/pronote/determinate-authentication-view.tsx
@@ -50,20 +50,6 @@ const determinateAuthenticationView = async <ScreenName extends keyof RouteParam
   });
 
   info(JSON.stringify(instance, null, 2), (new Error()).stack!);
-  if(pronoteURL.includes("demo.index-education.net")) {
-    showAlert({
-      title: "Instance non supportée",
-      message: "Désolé, les instances de démonstration ne sont pas supportées, elles peuvent être instables ou ne pas fonctionner correctement.",
-      actions: [
-        {
-          title: "Continuer quand même",
-          icon: <Check />,
-          primary: true,
-          backgroundColor: "#BE0B00",
-        },
-      ]
-    });
-  } 
   if (instance.casToken && instance.casURL) {
     showAlert({
       title: `L'instance ${instance.name} nécessite une connexion ENT.`,

--- a/src/views/login/pronote/PronoteManualURL.tsx
+++ b/src/views/login/pronote/PronoteManualURL.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import type { Screen } from "@/router/helpers/types";
+import type { RouteParameters, Screen } from "@/router/helpers/types";
 import { Platform, TextInput, View, StyleSheet, TouchableOpacity } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import determinateAuthenticationView from "@/services/pronote/determinate-authentication-view";
@@ -12,8 +12,9 @@ import MaskStars from "@/components/FirstInstallation/MaskStars";
 import PapillonShineBubble from "@/components/FirstInstallation/PapillonShineBubble";
 import ButtonCta from "@/components/FirstInstallation/ButtonCta";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Link2, X } from "lucide-react-native";
+import { Check, Link2, TriangleAlert, X } from "lucide-react-native";
 import { useAlert } from "@/providers/AlertProvider";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 const PronoteManualURL: Screen<"PronoteManualURL"> = ({ route, navigation }) => {
   const theme = useTheme();
@@ -50,6 +51,32 @@ const PronoteManualURL: Screen<"PronoteManualURL"> = ({ route, navigation }) => 
   useEffect(() => {
     setClipboardFound(false);
   }, [instanceURL]);
+  
+  const checkForDemoInstance = async <ScreenName extends keyof RouteParameters>(
+    instanceURL: string,
+    navigation: NativeStackNavigationProp<RouteParameters, ScreenName>,
+    showAlert: any
+  ): Promise<void> => {
+    if (!instanceURL.includes("demo.index-education.net")) return determinateAuthenticationView(instanceURL, navigation, showAlert);
+    showAlert({
+      title: "Instance non prise en charge",
+      message: "Désolé, les instances de démonstration ne sont pas prises en charge, elles peuvent être instables ou ne pas fonctionner correctement.",
+      actions: [
+        {
+          title: "Continuer",
+          primary: false,
+          icon: <TriangleAlert />,
+          onPress: () => determinateAuthenticationView(instanceURL, navigation, showAlert)
+        },
+        {
+          title: "Annuler",
+          icon: <Check />,
+          primary: true,
+          backgroundColor: "#29947A",
+        }
+      ]
+    });
+  };
 
   return (
     <View style={[
@@ -125,9 +152,8 @@ const PronoteManualURL: Screen<"PronoteManualURL"> = ({ route, navigation }) => 
         <ButtonCta
           value="Confirmer"
           primary
-          onPress={() => determinateAuthenticationView(instanceURL, navigation, showAlert)}
+          onPress={() => checkForDemoInstance(instanceURL, navigation, showAlert)}
         />
-
         {(route.params?.method) && (
           <ButtonCta
             value="Quitter"


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Ajout d'une alerte quand on souhaite se connecter avec une instance de démo pour éviter les issues inutiles. Idée venant de l'issue https://github.com/PapillonApp/Papillon/issues/57

## Informations supplémentaires

Comme l'a dit Vexcited dans l'issue https://github.com/PapillonApp/Papillon/issues/57 cette modification vérifie si l'URL contient ``demo.index-education.net``. Voilà a quoi ressemble l'alerte:
![image](https://github.com/user-attachments/assets/93f7cd6a-dcde-43d8-92bd-c8a1f89921eb)
