### PR TITLE
fix: use default name when reason is empty

### DIFF
--- a/src/views/account/Attendance/Atoms/AttendanceItem.tsx
+++ b/src/views/account/Attendance/Atoms/AttendanceItem.tsx
@@ -18,6 +18,8 @@ interface AttendanceItemProps {
   missed?: { hours: number, minutes: number }
 }
 
+const NO_JUSTICATION = "Sans justification";
+
 const AttendanceItem: React.FC<AttendanceItemProps> = ({
   title,
   icon,
@@ -80,7 +82,7 @@ const AttendanceItem: React.FC<AttendanceItemProps> = ({
 
         const timestamp = "fromTimestamp" in item ? item.fromTimestamp : item.timestamp;
         const not_justified = "justified" in item && !item.justified;
-        const justification = "reasons" in item ? item.reasons : "reason" in item ? item.reason.text : "Sans justification";
+        const justification = "reasons" in item ? item.reasons || NO_JUSTICATION : "reason" in item ? item.reason.text : NO_JUSTICATION;
 
         return (
           <NativeItem


### PR DESCRIPTION
Affiche "Sans justification" lorsque la justification est vide : `""`.

<img width="492" alt="image" src="https://github.com/user-attachments/assets/66512418-50ad-4c17-9eea-95e1cfbd020a">

Closes https://github.com/PapillonApp/Papillon/issues/63.