### PR TITLE
Add GetContribs utility function to fetch contributors excluding team members

### DIFF
--- a/src/utils/GetRessources/GetContribs.tsx
+++ b/src/utils/GetRessources/GetContribs.tsx
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import teams from '../../utils/data/teams.json';
+
+interface Contributor {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+}
+
+export async function getContributors(): Promise<Contributor[]> {
+  try {
+    const response = await axios.get('https://api.github.com/repos/PapillonApp/Papillon/contributors');
+    const allContributors: Contributor[] = response.data;
+
+    // Créer un ensemble des URLs GitHub de l'équipe
+    const teamGithubUrls = new Set(
+      teams
+        .filter(member => member.github)
+        .map(member => member.github.toLowerCase())
+    );
+
+    // Filtrer les contributeurs pour exclure les membres de l'équipe
+    const filteredContributors = allContributors.filter(contributor => 
+      !teamGithubUrls.has(contributor.html_url.toLowerCase())
+    );
+
+    // Retourner les contributeurs sans trier par nombre de contributions
+    return filteredContributors;
+  } catch (error) {
+    console.error('Erreur lors de la récupération des contributeurs:', error);
+    return [];
+  }
+}

--- a/src/utils/data/teams.json
+++ b/src/utils/data/teams.json
@@ -3,31 +3,36 @@
     "name": "Vince Linise",
     "description": "DBAV",
     "link": "https://vincelinise.com",
-    "ppimage": "https://avatars.githubusercontent.com/u/32978709?s=64&v=4"
+    "ppimage": "https://avatars.githubusercontent.com/u/32978709?s=64&v=4",
+    "github": "https://github.com/ecnivtwelve"
   },
   {
     "name": "Lucas Lavajo",
     "description": "Mainteneur",
     "link": "https://tryon-lab.fr",
-    "ppimage": "https://avatars.githubusercontent.com/u/68423470?s=64&v=4"
+    "ppimage": "https://avatars.githubusercontent.com/u/68423470?s=64&v=4",
+    "github": "https://github.com/tryon-dev"
   },
   {
     "name": "Mikkel Ringaud",
     "description": "Mainteneur",
     "link": "https://www.vexcited.com/",
-    "ppimage": "https://avatars.githubusercontent.com/u/59152884?s=64&v=4"
+    "ppimage": "https://avatars.githubusercontent.com/u/59152884?s=64&v=4",
+    "github": "https://github.com/Vexcited"
   },
   {
     "name": "Yann Renard",
     "description": "Mainteneur",
     "link": "https://github.com/yannouuuu",
-    "ppimage": "https://avatars.githubusercontent.com/u/76118368?s=64&v=4"
+    "ppimage": "https://avatars.githubusercontent.com/u/76118368?s=64&v=4",
+    "github": "https://github.com/yannouuuu"
   },
   {
     "name": "Emilien Orion",
     "description": "Communication",
     "link": "https://oriondev.fr/",
-    "ppimage": "https://avatars.githubusercontent.com/u/38093786?v=4"
+    "ppimage": "https://avatars.githubusercontent.com/u/38093786?v=4",
+    "github": "https://github.com/oriionn"
   },
   {
     "name": "Tom Helière",
@@ -39,6 +44,7 @@
     "name": "Rémy Godet",
     "description": "Développeur & Designer",
     "link": "https://godetremy.com/",
-    "ppimage": "https://avatars.githubusercontent.com/u/77058107?v=4"
+    "ppimage": "https://avatars.githubusercontent.com/u/77058107?v=4",
+    "github": "https://github.com/godetremy"
   }
 ]

--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Text, ScrollView, View, TouchableOpacity, StyleSheet, Image, Switch } from "react-native";
 import type { Screen } from "@/router/helpers/types";
 import { useTheme } from "@react-navigation/native";
@@ -14,6 +14,7 @@ import AboutContainerCard from "@/components/Settings/AboutContainerCard";
 import * as Linking from "expo-linking";
 import teams from "@/utils/data/teams.json";
 import Constants from "expo-constants";
+import { getContributors } from '@/utils/GetRessources/GetContribs';
 
 const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
   const theme = useTheme();
@@ -21,13 +22,20 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
   const insets = useSafeAreaInsets();
 
   const [clickedOnVersion, setClickedOnVersion] = React.useState<number>(0);
+  const [contributors, setContributors] = useState([]);
 
   useEffect(() => {
     if (clickedOnVersion == 7) {
       navigation.navigate("SettingsFlags");
       setClickedOnVersion(0);
     }
-  }, [clickedOnVersion]);
+    fetchContributors();
+  }, []);
+
+  const fetchContributors = async () => {
+    const fetchedContributors = await getContributors();
+    setContributors(fetchedContributors);
+  };
 
   return (
     <ScrollView
@@ -83,6 +91,29 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
           >
             <NativeText variant="title">{team.name}</NativeText>
             <NativeText variant="subtitle">{team.description}</NativeText>
+          </NativeItem>
+        ))}
+      </NativeList>
+
+      <NativeListHeader
+        label="Contributeurs GitHub"
+      />
+      <NativeList>
+        {contributors.map((contributor, index) => (
+          <NativeItem
+            onPress={() => Linking.openURL(contributor.html_url)}
+            chevron={true}
+            key={index}
+            leading={<Image
+              source={{ uri: contributor.avatar_url }}
+              style={{
+                width: 35,
+                height: 35,
+                borderRadius: 10,
+              }}
+            />}
+          >
+            <NativeText variant="title">{contributor.login}</NativeText>
           </NativeItem>
         ))}
       </NativeList>


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés
# Add GetContribs utility function and display GitHub contributors

This PR introduces a new utility function `getContributors` to fetch and filter GitHub contributors for the Papillon project. It also updates the SettingsAbout view to display these contributors.

## Changes

1. Added `src/utils/GetRessources/GetContribs.tsx`:
   - New utility function to fetch contributors from GitHub API
   - Filters out team members based on their GitHub URLs

2. Updated `src/utils/data/teams.json`:
   - Added `github` field for team members with their GitHub profile URLs

3. Modified `src/views/settings/SettingsAbout.tsx`:
   - Implemented fetching and displaying of GitHub contributors
   - Added a new section "Contributeurs GitHub" in the settings

## Benefits

- Recognizes and displays external contributors to the project
- Improves the "About" section by showcasing community involvement
- Provides an easy way to access contributors' GitHub profiles

## Notes

- The contributors are not sorted by the number of contributions
- Error handling is in place for failed API requests