### PR TITLE
feat: Add automatic login for demo instance in PronoteCredentials

### DIFF
--- a/src/views/login/pronote/PronoteCredentials.tsx
+++ b/src/views/login/pronote/PronoteCredentials.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import type { Screen } from "@/router/helpers/types";
 import { StyleSheet } from "react-native";
 
@@ -12,6 +12,16 @@ import LoginView from "@/components/Templates/LoginView";
 import extract_pronote_name from "@/utils/format/extract_pronote_name";
 
 const PronoteCredentials: Screen<"PronoteCredentials"> = ({ route, navigation }) => {
+  const [username, setUsername] = useState(route.params?.demoCredentials?.username || "");
+  const [password, setPassword] = useState(route.params?.demoCredentials?.password || "");
+
+  useEffect(() => {
+    if (route.params?.demoCredentials) {
+      // Soumettre automatiquement le formulaire avec les identifiants de démonstration
+      handleLogin(username, password);
+    }
+  }, []);
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/views/login/pronote/PronoteManualURL.tsx
+++ b/src/views/login/pronote/PronoteManualURL.tsx
@@ -51,7 +51,7 @@ const PronoteManualURL: Screen<"PronoteManualURL"> = ({ route, navigation }) => 
   useEffect(() => {
     setClipboardFound(false);
   }, [instanceURL]);
-  
+
   const checkForDemoInstance = async <ScreenName extends keyof RouteParameters>(
     instanceURL: string,
     navigation: NativeStackNavigationProp<RouteParameters, ScreenName>,
@@ -66,7 +66,14 @@ const PronoteManualURL: Screen<"PronoteManualURL"> = ({ route, navigation }) => 
           title: "Continuer",
           primary: false,
           icon: <TriangleAlert />,
-          onPress: () => determinateAuthenticationView(instanceURL, navigation, showAlert)
+          onPress: () => navigation.navigate("PronoteCredentials", {
+            instanceURL: instanceURL,
+            information: { name: "Demo Instance" },
+            demoCredentials: {
+              username: "demonstration",
+              password: "pronotevs"
+            }
+          })
         },
         {
           title: "Annuler",


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés
# Ajout de la connexion automatique pour l'instance de démonstration Pronote

## Description
Cette PR ajoute une fonctionnalité permettant la connexion automatique lorsqu'une instance de démonstration Pronote est détectée. Elle améliore l'expérience utilisateur en simplifiant le processus de connexion pour les comptes de démonstration.

## Changements principaux
- Modification de `PronoteCredentials.tsx` pour gérer les identifiants de démonstration
- Mise à jour de `PronoteManualURL.tsx` pour rediriger vers `PronoteCredentials` avec les identifiants pré-remplis
- Ajout d'un `useEffect` dans `PronoteCredentials` pour déclencher la connexion automatique

## Détails techniques
- Utilisation de `useState` pour initialiser les champs username et password avec les valeurs de démonstration
- Implémentation d'un `useEffect` pour soumettre automatiquement le formulaire si des identifiants de démonstration sont fournis
- Modification de la fonction `handleLogin` pour accepter les paramètres username et password

## Tests effectués
- Vérification du fonctionnement correct de la connexion automatique pour l'instance de démonstration
- Test du comportement normal pour les instances non-démo

## Notes supplémentaires
Cette fonctionnalité facilite les tests et les démonstrations de l'application, tout en maintenant l'avertissement pour les utilisateurs concernant la nature potentiellement instable des instances de démonstration.