### PR TITLE
refactor(settings/subjects): simplify redundant call to `setOnSubjects`

### DIFF
--- a/src/views/settings/SettingsSubjects.tsx
+++ b/src/views/settings/SettingsSubjects.tsx
@@ -207,39 +207,28 @@ const SettingsSubjects: Screen<"SettingsSubjects"> = ({ navigation }) => {
                     }}
                     value={subjects.find((subject) => subject[0] === selectedSubject[0])?.[1].emoji}
                     onChangeText={(text) => {
-                      if (text.length < 1) {
-                        setOnSubjects(
-                          subjects.map((subject) => {
-                            if (subject[0] === selectedSubject[0]) {
-                              return [selectedSubject[0], {
-                                ...subject[1],
-                                emoji: "",
-                              }];
-                            }
-                            return subject;
-                          })
-                        );
-                        return;
-                      } else {
+                      let emoji = "";
+                      if(text.length >= 1) {
                         var regexp = /((\ud83c[\udde6-\uddff]){2}|([#*0-9]\u20e3)|(\u00a9|\u00ae|[\u2000-\u3300]|[\ud83c-\ud83e][\ud000-\udfff])((\ud83c[\udffb-\udfff])?(\ud83e[\uddb0-\uddb3])?(\ufe0f?\u200d([\u2000-\u3300]|[\ud83c-\ud83e][\ud000-\udfff])\ufe0f?)?)*)/g;
 
                         const emojiMatch = text.match(regexp);
 
-                        if (emojiMatch) {
-                          const lastEmoji = emojiMatch[emojiMatch.length - 1];
-                          setOnSubjects(
-                            subjects.map((subject) => {
-                              if (subject[0] === selectedSubject[0]) {
-                                return [selectedSubject[0], {
-                                  ...subject[1],
-                                  emoji: lastEmoji,
-                                }];
-                              }
-                              return subject;
-                            })
-                          );
+                        if(emojiMatch) {
+                          emoji = emojiMatch[emojiMatch.length - 1];
                         }
                       }
+                      
+                      setOnSubjects(
+                        subjects.map((subject) => {
+                          if (subject[0] === selectedSubject[0]) {
+                            return [selectedSubject[0], {
+                              ...subject[1],
+                              emoji: emoji,
+                            }];
+                          }
+                          return subject;
+                        })
+                      );
                     }}
                   />
                 </MemoizedNativeItem>

--- a/src/views/settings/SettingsSubjects.tsx
+++ b/src/views/settings/SettingsSubjects.tsx
@@ -217,7 +217,7 @@ const SettingsSubjects: Screen<"SettingsSubjects"> = ({ navigation }) => {
                           emoji = emojiMatch[emojiMatch.length - 1];
                         }
                       }
-                      
+
                       setOnSubjects(
                         subjects.map((subject) => {
                           if (subject[0] === selectedSubject[0]) {


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [ ] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
> Testé sous Expo Go, tout fonctionne parfaitement.
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

There was a redundant call to `setOnSubjects` (one if no emoji was provided and another if one or more emoji were provided). This commit/PR simplifies the redundant call by using an external variable. It also does away with a useless `return call`. Note that there is a small delay between appending a second emoji and it being selected as the emoji for the subject.