### PR TITLE
fix(home): plusieurs changements

### DIFF
--- a/src/router/screens/index.ts
+++ b/src/router/screens/index.ts
@@ -13,7 +13,9 @@ export default [
 
   createScreen("SettingStack", SettingsScreen, {
     headerShown: false,
-    presentation: "modal"
+    presentation: "modal",
+    animation: "slide_from_right",
+    animationDuration: 100
   }),
 
   createScreen("AccountStack", AccountScreen, {

--- a/src/views/account/Home/Elements/HomeworksElement.tsx
+++ b/src/views/account/Home/Elements/HomeworksElement.tsx
@@ -35,9 +35,11 @@ const HomeworksElement = () => {
     [account, updateHomeworks]
   );
 
-  if (!homeworks[dateToEpochWeekNumber(actualDay)] || homeworks[dateToEpochWeekNumber(actualDay)]?.filter(hw => new Date(hw.due).getDate() === actualDay.getDate()).length === 0) {
-    return null;
-  }
+  // if (!homeworks[dateToEpochWeekNumber(actualDay)] || homeworks[dateToEpochWeekNumber(actualDay)]?.filter(hw => new Date(hw.due).getDate() === actualDay.getDate()).length === 0) {
+  //   return null;
+  // }
+  const startTime = Date.now() / 1000; // Convertir en millisecondes
+  const endTime = startTime + 7 * 24 * 60 * 60 * 1000; // Ajouter 7 jours en millisecondes
 
   return (
     <>
@@ -47,12 +49,23 @@ const HomeworksElement = () => {
         )}
       />
       <NativeList>
-        {homeworks[dateToEpochWeekNumber(actualDay)]?.filter(hw => new Date(hw.due).getDate() === actualDay.getDate()).map((hw, index) => (
+        {homeworks[dateToEpochWeekNumber(actualDay)]?.filter(hw => hw.due / 1000 >= startTime && hw.due / 1000 <= endTime).map((hw, index) => (
           <HomeworkItem
             homework={hw}
             key={index}
             index={index}
-            total={homeworks[dateToEpochWeekNumber(actualDay)].length}
+            total={homeworks[dateToEpochWeekNumber(actualDay) + 1].length}
+            onDonePressHandler={() => {
+              handleDonePress(hw);
+            }}
+          />
+        ))}
+        {new Date().getDay() >= 2 && homeworks[dateToEpochWeekNumber(actualDay) + 1]?.filter(hw => hw.due / 1000 >= startTime && hw.due / 1000 <= endTime).map((hw, index) => (
+          <HomeworkItem
+            homework={hw}
+            key={index}
+            index={index}
+            total={homeworks[dateToEpochWeekNumber(actualDay) + 1].length}
             onDonePressHandler={() => {
               handleDonePress(hw);
             }}

--- a/src/views/account/Home/Elements/TimetableElement.tsx
+++ b/src/views/account/Home/Elements/TimetableElement.tsx
@@ -3,7 +3,11 @@ import { useCurrentAccount } from "@/stores/account";
 import { useTimetableStore } from "@/stores/timetable";
 import { animPapillon } from "@/utils/ui/animations";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import Reanimated, { FadeInDown, FadeOut, LinearTransition } from "react-native-reanimated";
+import Reanimated, {
+  FadeInDown,
+  FadeOut,
+  LinearTransition,
+} from "react-native-reanimated";
 import { TimetableItem } from "../../Lessons/Atoms/Item";
 import { PapillonNavigation } from "@/router/refs";
 import RedirectButton from "@/components/Home/RedirectButton";
@@ -41,18 +45,15 @@ const TimetableElement = () => {
     );
   };
 
-  const epochWeekNumber = useMemo(
-    () => dateToEpochWeekNumber(new Date()),
-    []
-  );
+  const epochWeekNumber = useMemo(() => dateToEpochWeekNumber(new Date()), []);
 
   const [currentlyUpdating, setCurrentlyUpdating] = useState(false);
 
   useEffect(() => {
     if (
       !timetables[epochWeekNumber] &&
-          !currentlyUpdating &&
-          account.instance
+      !currentlyUpdating &&
+      account.instance
     ) {
       setCurrentlyUpdating(true);
       updateTimetableForWeekInCache(account, epochWeekNumber);
@@ -92,11 +93,18 @@ const TimetableElement = () => {
 
       const allCourses = Object.values(timetables).flat();
       const now = new Date();
-      const today = now.getTime();
+      const today = parseInt((now.getTime() / 1000).toString());
+      const tomorrow = today + 1 * 24 * 60 * 60; // Ajouter 1 jour en millisecondes
+      const Bistomorrow = today + 2 * 24 * 60 * 60; // Ajouter 1 jour en millisecondes
 
-      const sortedCourses = allCourses
-        .filter((c) => c.endTimestamp > today)
-        .sort((a, b) => a.startTimestamp - b.startTimestamp);
+      const sortedCourses =
+        allCourses.filter((c) => c.startTimestamp / 1000 < Date.now() / 1000).length !== 0
+          ? allCourses
+            .filter((c) => c.endTimestamp / 1000 > today && c.endTimestamp / 1000 < tomorrow)
+            .sort((a, b) => a.startTimestamp - b.startTimestamp)
+          : allCourses
+            .filter((c) => c.endTimestamp / 1000 > tomorrow && c.endTimestamp / 1000 < Bistomorrow)
+            .sort((a, b) => a.startTimestamp - b.startTimestamp);
 
       let nextThreeCourses: TimetableClass[] = [];
       let verif: string[] = [];

--- a/src/views/account/Home/Elements/TimetableElement.tsx
+++ b/src/views/account/Home/Elements/TimetableElement.tsx
@@ -99,12 +99,20 @@ const TimetableElement = () => {
         .sort((a, b) => a.startTimestamp - b.startTimestamp);
 
       let nextThreeCourses: TimetableClass[] = [];
+      let verif: string[] = [];
       let currentDay = now;
 
       for (const course of sortedCourses) {
         if (isSameDay(course.startTimestamp, currentDay.getTime())) {
-          nextThreeCourses.push(course);
-          if (nextThreeCourses.length === 3) break;
+          if (
+            ((nextThreeCourses.length === 1 &&
+              nextThreeCourses[0].endTimestamp !== course.endTimestamp) ||
+              nextThreeCourses.length > 1) &&
+            !verif.includes(`${course.endTimestamp}|${course.startTimestamp}`)
+          ) {
+            nextThreeCourses.push(course);
+            verif.push(`${course.endTimestamp}|${course.startTimestamp}`);
+          }
         } else if (nextThreeCourses.length > 0) {
           break;
         } else {
@@ -158,18 +166,15 @@ const TimetableElement = () => {
           <React.Fragment key={course.id || index}>
             <TimetableItem item={course} index={index} small />
             {nextCourses[index + 1] &&
-                          isSameDay(
-                            course.endTimestamp,
-                            nextCourses[index + 1].startTimestamp
-                          ) &&
-                          nextCourses[index + 1].startTimestamp -
-                              course.endTimestamp >
-                              1740000 && (
+              isSameDay(
+                course.endTimestamp,
+                nextCourses[index + 1].startTimestamp
+              ) &&
+              nextCourses[index + 1].startTimestamp - course.endTimestamp >
+                1740000 && (
               <SeparatorCourse
                 i={index}
-                start={
-                  nextCourses[index + 1].startTimestamp
-                }
+                start={nextCourses[index + 1].startTimestamp}
                 end={course.endTimestamp}
               />
             )}

--- a/src/views/account/Home/Elements/TimetableElement.tsx
+++ b/src/views/account/Home/Elements/TimetableElement.tsx
@@ -93,14 +93,12 @@ const TimetableElement = () => {
 
       const allCourses = Object.values(timetables).flat();
       const now = new Date();
-      const today = parseInt((now.getTime() / 1000).toString());
+      const today = parseInt(((new Date(`${new Date().getFullYear()}-${(new Date().getMonth() + 1).toString().padStart(2, "0")}-${(new Date().getDate()).toString().padStart(2, "0")}T00:00:00Z`)).getTime() / 1000).toString());
       const tomorrow = today + 1 * 24 * 60 * 60; // Ajouter 1 jour en millisecondes
       const Bistomorrow = today + 2 * 24 * 60 * 60; // Ajouter 1 jour en millisecondes
-
       const sortedCourses =
-        allCourses.filter((c) => c.startTimestamp / 1000 < Date.now() / 1000).length !== 0
-          ? allCourses
-            .filter((c) => c.endTimestamp / 1000 > today && c.endTimestamp / 1000 < tomorrow)
+        allCourses.filter((c) => c.startTimestamp / 1000 > Date.now() / 1000 && c.startTimestamp / 1000 < tomorrow).length !== 0
+          ? allCourses.filter((c) => c.startTimestamp / 1000 > Date.now() / 1000 && c.startTimestamp / 1000 < tomorrow)
             .sort((a, b) => a.startTimestamp - b.startTimestamp)
           : allCourses
             .filter((c) => c.endTimestamp / 1000 > tomorrow && c.endTimestamp / 1000 < Bistomorrow)
@@ -115,7 +113,7 @@ const TimetableElement = () => {
           if (
             ((nextThreeCourses.length === 1 &&
               nextThreeCourses[0].endTimestamp !== course.endTimestamp) ||
-              nextThreeCourses.length > 1) &&
+              nextThreeCourses.length !== 1) &&
             !verif.includes(`${course.endTimestamp}|${course.startTimestamp}`)
           ) {
             nextThreeCourses.push(course);


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Plusieurs changements ont été effectuées, j'essaye de les détailler le plus possible : 

- `index.ts` -> Correction d'un écran blanc aléatoire lors de l'ouverture des paramètres, _voir vidéo_ (#140 )
- `HomeworksElement.tsx` -> Dans mon cas, ça affichait uniquement les devoirs de ce jour. Maintenant, ça affiche tous les devoirs sur les 7 jours à venir
- `TimetableElement.tsx` -> Depuis quelques temps, quand ça affichait mon emploi du temps, ça dupliquait toutes les matières du cours. Désormais, ça ne duplique plus et ça affiche tous les cours du jour qui n'ont pas eu lieu (_ou l'emploi du temps du lendemain_), voir photos

## Informations supplémentaires

1. `index.ts` : 

https://github.com/user-attachments/assets/7232745e-3832-4392-92e9-901910174dbb

2. `TimetableElement.tsx` : 
- Avant : ![1725905242879](https://github.com/user-attachments/assets/8e354b33-d095-449e-9e3b-fdcfc5218c3e)
- Après : ![1725905242873](https://github.com/user-attachments/assets/dd0232e0-fa9c-4cc7-826a-34841b33142a)