### PR TITLE
feat: Illustrations sur le sélecteur de compte

### DIFF
--- a/src/components/Global/NativeComponents.tsx
+++ b/src/components/Global/NativeComponents.tsx
@@ -349,7 +349,7 @@ export const NativeIcon: React.FC<NativeIconProps> = ({ icon, color, style }) =>
 
 interface NativeTextProps {
   children: ReactNode;
-  variant?: "title" | "titleLarge" | "subtitle" | "overtitle" | "body"| "default";
+  variant?: "title" | "titleLarge" | "subtitle" | "overtitle" | "body"| "default" | "titleLarge2";
   color?: string;
   style?: StyleProp<TextStyle>;
   numberOfLines?: number;
@@ -378,6 +378,13 @@ export const NativeText: React.FC<NativeTextProps> = (props) => {
         fontFamily: "semibold",
         fontSize: 19,
         lineHeight: 24,
+      };
+      break;
+    case "titleLarge2":
+      fontStyle = {
+        fontFamily: "bold",
+        fontSize: 24,
+        lineHeight: 28,
       };
       break;
     case "subtitle":

--- a/src/consts/datasets.json
+++ b/src/consts/datasets.json
@@ -1,4 +1,5 @@
 {
   "kofi-supporters": "https://raw.githubusercontent.com/PapillonApp/datasets/main/kofi-supporters.json",
-  "changelog": "https://raw.githubusercontent.com/PapillonApp/datasets/main/updates/[version].json"
+  "changelog": "https://raw.githubusercontent.com/PapillonApp/datasets/main/updates/[version].json",
+  "illustrations": "https://raw.githubusercontent.com/PapillonApp/datasets/refs/heads/main/illustrations/index.json"
 }

--- a/src/views/welcome/AccountSelector.tsx
+++ b/src/views/welcome/AccountSelector.tsx
@@ -99,6 +99,14 @@ const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
         flex: 1,
       }}
     >
+      {isFocused && (
+        <StatusBar
+          barStyle="light-content"
+          backgroundColor="transparent"
+          translucent
+        />
+      )}
+
       <Reanimated.View
         style={{
           width: "100%",

--- a/src/views/welcome/AccountSelector.tsx
+++ b/src/views/welcome/AccountSelector.tsx
@@ -4,15 +4,18 @@ import { defaultProfilePicture } from "@/utils/ui/default-profile-picture";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { PlusIcon } from "lucide-react-native";
 import { useEffect, useState } from "react";
-import {ActivityIndicator, Image, StatusBar, View } from "react-native";
+import {ActivityIndicator, Image, RefreshControl, StatusBar, Text, TouchableHighlight, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as SplashScreen from "expo-splash-screen";
 
 import PapillonAvatar from "@/components/Global/PapillonAvatar";
 
+import PackageJSON from "@/../package.json";
+
 import Reanimated, {
   FadeInDown,
   FadeInUp,
+  FadeOut,
   FadeOutUp,
   LinearTransition,
   ZoomIn,
@@ -22,6 +25,9 @@ import { animPapillon } from "@/utils/ui/animations";
 import { Screen } from "@/router/helpers/types";
 import { AccountService } from "@/stores/account/types";
 import PapillonSpinner from "@/components/Global/PapillonSpinner";
+import { PressableScale } from "react-native-pressable-scale";
+
+import datasets from "@/consts/datasets.json";
 
 const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
   const theme = useTheme();
@@ -35,6 +41,26 @@ const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
   const accounts = useAccounts((store) => store.accounts);
 
   const [loading, setLoading] = useState(null);
+
+  const [downloadedIllustrations, setDownloadedIllustrations] = useState(false);
+  const [illustration, setIllustration] = useState(null);
+  const [illustrationLoaded, setIllustrationLoaded] = useState(false);
+
+  useEffect(() => {
+    if(!downloadedIllustrations) {
+      updateIllustration();
+    }
+  }, []);
+
+  const updateIllustration = async () => {
+    fetch(datasets["illustrations"])
+      .then((response) => response.json())
+      .then((data) => {
+        setDownloadedIllustrations(true);
+        // select a random illustration
+        setIllustration(data[Math.floor(Math.random() * data.length)]);
+      });
+  };
 
   useEffect(() => {
     void async function () {
@@ -71,62 +97,169 @@ const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
     <View
       style={{
         flex: 1,
-        padding: 16,
-        paddingTop: insets.top + 16,
-        paddingBottom: insets.bottom + 16,
       }}
     >
-      {isFocused && (
-        <StatusBar
-          barStyle={theme.dark ? "light-content" : "dark-content"}
-          backgroundColor={"transparent"}
-          translucent
-        />
-      )}
-
-      <LinearGradient
-        colors={["#29947a", theme.colors.background]}
-        style={{
-          position: "absolute",
-          left: 0,
-          right: 0,
-          top: 0,
-          height: "35%",
-          opacity: 0.2,
-          zIndex: -1,
-        }}
-        pointerEvents="none"
-      />
-
       <Reanimated.View
-        entering={animPapillon(FadeInUp)}
         style={{
-          flexDirection: "row",
-          alignItems: "center",
-          marginBottom: 16,
-          gap: 16,
+          width: "100%",
+          aspectRatio: 5 / 3,
+
+          borderBottomColor: theme.colors.border,
+          borderBottomWidth: 1,
         }}
       >
-        <Image
-          source={require("@/../assets/images/icon_papillon.png")}
+        {!illustrationLoaded &&
+          <Reanimated.View
+            style={{
+              width: "100%",
+              height: "100%",
+              position: "absolute",
+              top: 0,
+              left: 0,
+              backgroundColor: "#1E212D",
+              zIndex: 3,
+            }}
+            exiting={FadeOut}
+          />
+        }
+
+        <Reanimated.Image
+          source={illustration && { uri: illustration.image }}
           style={{
-            width: 26,
-            aspectRatio: 1,
+            width: "100%",
+            height: "100%",
           }}
-          tintColor={theme.colors.text}
+          onLoad={() => setIllustrationLoaded(true)}
         />
 
-        <View>
-          <NativeText variant="titleLarge">
-            Ravis de vous revoir !
-          </NativeText>
-          <NativeText variant="subtitle">
-            Sélectionnez un compte pour commencer
-          </NativeText>
+        <LinearGradient
+          colors={["#00000000", "#000000"]}
+          locations={[0.5, 0.8]}
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: "0%",
+            height: "100%",
+            opacity: 0.85,
+            zIndex: 5
+          }}
+        />
+
+        <View
+          style={{
+            position: "absolute",
+            left: 16,
+            right: 16,
+            bottom: 16,
+            gap: 4,
+            zIndex: 9
+          }}
+        >
+          <Text
+            style={{
+              color: "#ffffff",
+              fontSize: 18,
+              fontFamily: "bold",
+            }}
+          >
+            Bienvenue sur Papillon !
+          </Text>
+
+          <Text
+            style={{
+              color: "#ffffff",
+              fontSize: 15,
+              fontFamily: "medium",
+              opacity: 0.8,
+            }}
+          >
+            Sélectionnez un compte pour commencer.
+          </Text>
         </View>
       </Reanimated.View>
 
-      <Reanimated.ScrollView>
+      <PressableScale
+        style={{
+          zIndex: 99999999,
+          position: "absolute",
+          right: 20,
+          bottom: 16 + insets.bottom,
+          flexDirection: "row",
+          alignItems: "center",
+          paddingHorizontal: 16,
+          paddingVertical: 10,
+          gap: 10,
+          borderRadius: 100,
+          backgroundColor: theme.colors.primary,
+          shadowColor: "#000000",
+          shadowOffset: {
+            width: 0,
+            height: 2,
+          },
+          shadowOpacity: 0.2,
+          shadowRadius: 4,
+        }}
+        onPress={() => navigation.navigate("ServiceSelector")}
+      >
+        <PlusIcon
+          size={24}
+          strokeWidth={2.5}
+          color={"#fff"}
+        />
+
+        <Text
+          style={{
+            color: "#ffffff",
+            fontFamily: "semibold",
+            fontSize: 16,
+          }}
+        >
+          Ajouter un compte
+        </Text>
+      </PressableScale>
+
+      <TouchableHighlight
+        style={{
+          position: "absolute",
+          bottom: 16 + insets.bottom,
+          left: 16,
+          alignSelf: "flex-start",
+          opacity: 0.4,
+          zIndex: 99999999,
+          paddingHorizontal: 8,
+          marginHorizontal: -8,
+          paddingVertical: 4,
+          borderRadius: 5,
+        }}
+        underlayColor={theme.colors.text + "44"}
+        onLongPress={() => navigation.navigate("DevMenu")}
+        delayLongPress={2000}
+      >
+        <NativeText
+          style={{
+            fontSize: 12,
+          }}
+        >
+          ver. {PackageJSON.version}
+        </NativeText>
+      </TouchableHighlight>
+
+      <Reanimated.ScrollView
+        style={{
+          padding: 16,
+          paddingBottom: insets.bottom + 16,
+          paddingTop: 0
+        }}
+        refreshControl={
+          <RefreshControl
+            refreshing={false}
+            onRefresh={() => {
+              updateIllustration();
+            }}
+          />
+        }
+      >
         {accounts.filter((account) => !account.isExternal).length > 0 && (
           <Reanimated.View
             entering={animPapillon(FadeInDown)}
@@ -208,19 +341,11 @@ const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
           </Reanimated.View>
         )}
 
-        <Reanimated.View
-          entering={animPapillon(FadeInDown).delay(100)}
-          layout={animPapillon(LinearTransition)}
-        >
-          <NativeListHeader label="Gestion des comptes" />
-          <NativeList>
-            <NativeItem
-              icon={<PlusIcon />}
-              subtitle="Ajouter un compte"
-              onPress={() => navigation.navigate("ServiceSelector")}
-            />
-          </NativeList>
-        </Reanimated.View>
+        <View
+          style={{
+            height: 100,
+          }}
+        />
       </Reanimated.ScrollView>
     </View>
   );

--- a/src/views/welcome/AccountSelector.tsx
+++ b/src/views/welcome/AccountSelector.tsx
@@ -4,7 +4,7 @@ import { defaultProfilePicture } from "@/utils/ui/default-profile-picture";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { PlusIcon } from "lucide-react-native";
 import { useEffect, useState } from "react";
-import {ActivityIndicator, Image, RefreshControl, StatusBar, Text, TouchableHighlight, View } from "react-native";
+import {ActivityIndicator, Alert, Image, RefreshControl, StatusBar, Text, TouchableHighlight, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as SplashScreen from "expo-splash-screen";
 
@@ -37,6 +37,7 @@ const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
 
   const currentAccount = useCurrentAccount((store) => store.account);
   const switchTo = useCurrentAccount((store) => store.switchTo);
+  const removeAccount = useAccounts((store) => store.remove);
 
   const accounts = useAccounts((store) => store.accounts);
 
@@ -308,6 +309,42 @@ const AccountSelector: Screen<"AccountSelector"> = ({ navigation }) => {
                         />
                       )
                     }
+                    onLongPress={async () => {
+                      // delete account
+                      Alert.alert(
+                        "Supprimer le compte",
+                        "Êtes-vous sûr de vouloir supprimer ce compte ?",
+                        [
+                          {
+                            text: "Annuler",
+                            style: "cancel",
+                          },
+                          {
+                            text: "Supprimer",
+                            style: "destructive",
+                            onPress: () => {
+                              Alert.alert(
+                                "Êtes-vous sûr ?",
+                                "Voulez-vous supprimer définitivement " + account.studentName.first + " " + account.studentName.last + " ?",
+                                [
+                                  {
+                                    text: "Annuler",
+                                    style: "cancel",
+                                  },
+                                  {
+                                    text: "Supprimer",
+                                    style: "destructive",
+                                    onPress: () => {
+                                      removeAccount(account.localID);
+                                    },
+                                  },
+                                ]
+                              );
+                            },
+                          },
+                        ]
+                      );
+                    }}
                     onPress={async () => {
                       if (currentAccount?.localID !== account.localID) {
                         setLoading(account.localID);

--- a/src/views/welcome/DevMenu.tsx
+++ b/src/views/welcome/DevMenu.tsx
@@ -1,8 +1,10 @@
 import { useTheme } from "@react-navigation/native";
 import { ChevronRight } from "lucide-react-native";
 import React, { useLayoutEffect } from "react";
-import { View, Text, TouchableOpacity, ScrollView, Button } from "react-native";
+import { View, Text, TouchableOpacity, ScrollView, Button, Alert } from "react-native";
 import type { Screen } from "@/router/helpers/types";
+import { NativeItem, NativeList, NativeListHeader, NativeText } from "@/components/Global/NativeComponents";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const DevMenu: Screen<"DevMenu"> = ({ navigation }) => {
   const theme = useTheme();
@@ -46,11 +48,13 @@ const DevMenu: Screen<"DevMenu"> = ({ navigation }) => {
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={{
+        padding: 16,
+      }}
     >
       <View
         style={{
           backgroundColor: colors.text + "16",
-          margin: 16,
           borderRadius: 10,
           borderCurve: "continuous",
           padding: 16,
@@ -81,25 +85,87 @@ const DevMenu: Screen<"DevMenu"> = ({ navigation }) => {
         </Text>
       </View>
 
-      <Button
-        title="Go to Account Selector"
-        onPress={() => navigation.navigate("AccountSelector")}
-      />
+      {__DEV__ && (
+        <View>
+          <NativeListHeader label="Options de développement" />
 
-      <Button
-        title="NoteReaction"
-        onPress={() => navigation.navigate("NoteReaction")}
-      />
+          <NativeList>
 
-      <Button
-        title="ColorSelector"
-        onPress={() => navigation.navigate("ColorSelector")}
-      />
+            <NativeItem
+              onPress={() => navigation.navigate("AccountSelector")}
+            >
+              <NativeText>
+                Go to Account Selector
+              </NativeText>
+            </NativeItem>
 
-      <Button
-        title="AccountCreated"
-        onPress={() => navigation.navigate("AccountCreated")}
-      />
+            <NativeItem
+              onPress={() => navigation.navigate("NoteReaction")}
+            >
+              <NativeText>
+                NoteReaction
+              </NativeText>
+            </NativeItem>
+
+            <NativeItem
+              onPress={() => navigation.navigate("ColorSelector")}
+            >
+              <NativeText>
+                ColorSelector
+              </NativeText>
+            </NativeItem>
+
+            <NativeItem
+              onPress={() => navigation.navigate("AccountCreated")}
+            >
+              <NativeText>
+                AccountCreated
+              </NativeText>
+            </NativeItem>
+
+          </NativeList>
+        </View>
+      )}
+
+      <View>
+        <NativeListHeader label="Options de développement" />
+
+        <NativeList>
+
+          <NativeItem
+            onPress={() => {
+              Alert.alert(
+                "Reset all data",
+                "Are you sure you want to reset all data?",
+                [
+                  {
+                    text: "Cancel",
+                    style: "cancel",
+                  },
+                  {
+                    text: "Reset",
+                    style: "destructive",
+                    onPress: () => {
+                      AsyncStorage.clear();
+                      navigation.popToTop();
+                    },
+                  },
+                ],
+              );
+            }}
+          >
+            <NativeText
+              style={{
+                color: "#E91E63",
+                fontFamily: "semibold",
+              }}
+            >
+              Erase all Papillon data and settings
+            </NativeText>
+          </NativeItem>
+        </NativeList>
+      </View>
+
     </ScrollView>
   );
 };


### PR DESCRIPTION
### Changements
Utilisation des [datasets](https://github.com/PapillonApp/datasets/tree/main/illustrations) pour obtenir une illustration dans le selecteur de compte
> *Ca peut être vachement cool de permettre à la communauté de proposer des illustrations qui seront dans l'app*

### Screenshot
| Clair | Sombre |
| -- | -- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-09-23 at 11 26 14](https://github.com/user-attachments/assets/ebfd1de9-c35b-4fdf-be20-862cf3f175d6) | ![Simulator Screenshot - iPhone 15 Pro - 2024-09-23 at 11 26 22](https://github.com/user-attachments/assets/00ceeb84-bd7f-4e22-80da-a36ff7ae969e) |
