### PR TITLE
feat(AccountStack): Added deep link to auto import iCal URLs

### DIFF
--- a/src/router/helpers/types.ts
+++ b/src/router/helpers/types.ts
@@ -60,7 +60,11 @@ export type RouteParameters = {
   NoteReaction: undefined;
 
   Lessons?: { outsideNav?: boolean };
-  LessonsImportIcal: undefined;
+  LessonsImportIcal: {
+    ical?: string;
+    title?: string;
+    autoAdd?: boolean;
+  };
 
   Homeworks?: { outsideNav?: boolean };
   HomeworksDocument: { homework: Homework };

--- a/src/router/screens/account/stack.tsx
+++ b/src/router/screens/account/stack.tsx
@@ -7,6 +7,8 @@ import PapillonTabNavigator from "@/router/helpers/PapillonTabNavigator";
 import { Screen } from "@/router/helpers/types";
 
 import * as SplashScreen from "expo-splash-screen";
+import * as Linking from "expo-linking";
+import { PapillonNavigation } from "@/router/refs";
 
 export const AccountStack = PapillonTabNavigator();
 const screenOptions: NativeStackNavigationOptions = {
@@ -31,6 +33,27 @@ function TabBarContainer () {
 
 const AccountStackScreen: Screen<"AccountStack"> = () => {
   const account = useCurrentAccount(store => store.account);
+
+  const navigatorRef = React.useRef();
+
+  const url = Linking.useURL();
+  const params = url && Linking.parse(url);
+
+  useEffect(() => {
+    if (params) {
+      if (params.queryParams.method == "importIcal") {
+        const ical = params.queryParams.ical;
+        const title = params.queryParams.title;
+        const autoAdd = params.queryParams.autoAdd;
+
+        PapillonNavigation.current?.navigate("LessonsImportIcal", {
+          ical,
+          title,
+          autoAdd,
+        });
+      }
+    }
+  }, [params]);
 
   const dims = Dimensions.get("window");
   const tablet = dims.width > 600;

--- a/src/services/timetable.ts
+++ b/src/services/timetable.ts
@@ -18,8 +18,6 @@ export async function updateTimetableForWeekInCache <T extends Account> (account
       break;
     }
     case AccountService.Local: {
-      const timetable = [];
-      useTimetableStore.getState().updateClasses(epochWeekNumber, []);
       break;
     }
     case AccountService.Skolengo: {

--- a/src/views/account/Lessons/Lessons.tsx
+++ b/src/views/account/Lessons/Lessons.tsx
@@ -41,6 +41,13 @@ const Lessons: Screen<"Lessons"> = ({ route, navigation }) => {
   let currentlyLoadingWeeks = useRef<Set<number>>(new Set());
   let lastAccountID = useRef<string | null>(null);
 
+  useEffect(() => {
+    // add all week numbers in timetables to loadedWeeks
+    for (const week in timetables) {
+      loadedWeeks.current.add(parseInt(week));
+    }
+  }, [timetables]);
+
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -60,6 +67,10 @@ const Lessons: Screen<"Lessons"> = ({ route, navigation }) => {
       await loadTimetableWeek(weekNumber, false);
     })();
   }, [pickerDate, account.instance]);
+
+  useEffect(() => {
+    loadTimetableWeek(getWeekFromDate(new Date()), true);
+  }, [account.personalization.icalURLs]);
 
   const [loadingWeeks, setLoadingWeeks] = useState([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
- Ability to auto import iCal links like `papillon://?method=importIcal&ical=(link)&title=(title)&autoAdd=true`

### Example :
https://github.com/user-attachments/assets/e4f74381-5425-491d-af93-6ca921304e7f

