### PR TITLE
fix(Lessons) : Display item.statusText instead of item.status in lessons view

### DIFF
--- a/src/views/account/Lessons/Atoms/Item.tsx
+++ b/src/views/account/Lessons/Atoms/Item.tsx
@@ -62,9 +62,9 @@ export const TimetableItem: React.FC<{
         }}
       >
         <View style={[{ flex: 1, flexDirection: "column", overflow: "hidden", borderRadius: 10 }]}>
-          {item.status && (
+          {item.statusText && (
             <View style={[styles.statusContainer, { backgroundColor: item.status === TimetableClassStatus.CANCELED ? "#E8BEBF" : subjectData.color + "33" }]}>
-              <Text style={[styles.statusText, { color: item.status === TimetableClassStatus.CANCELED ? "#B42828" :  subjectData.color}]}>{item.status}</Text>
+              <Text style={[styles.statusText, { color: item.status === TimetableClassStatus.CANCELED ? "#B42828" :  subjectData.color}]}>{item.statusText}</Text>
             </View>
           )}
 


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Affichage du statut du cours dans le bandeau

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Affichage du statut du cours (Cours annulé Prof. absent,  Classe absente...) dans le bandeau pour remplacer le texte actuel "canceled". (Voir screen)

## Screen

![canceled](https://github.com/user-attachments/assets/b6ecd717-ed4f-4fd8-8ec8-a54253a5cf1e)
![statut](https://github.com/user-attachments/assets/277e27be-4006-42b6-9911-d106d494e91a)

## C'est une PR qui remplace #216 
