### PR TITLE
fix crashing when restoring from background

### DIFF
--- a/android/app/src/main/java/xyz/getpapillon/app/MainActivity.kt
+++ b/android/app/src/main/java/xyz/getpapillon/app/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : ReactActivity() {
     // coloring the background, status bar, and navigation bar.
     // This is required for expo-splash-screen.
     setTheme(R.style.AppTheme);
-    super.onCreate(savedInstanceState);
+    super.onCreate(null); // Null is important, it prevent fragments to be restored and cause app crash
   }
 
   /**


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Lors-ce que l'appli est passée en background (quand on la quitte sans la fermer complètement) et qu'on la redémarre alors qu'android l'a arrêté, android va vouloir restaurer les écrans de celle-ci sauf que cela fait crash l'appli : 
```
java.lang.IllegalStateException: Screen fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17 to properly configure your main activity.
```
J'ai donc corrigé cela en faisant en sorte que lors-ce que l'activité est créée, elle soit créée de 0.
Après avoir testé en off cette solution et avoir vu qu'elle fonctionne, j'ai publié une version de l'appli avec ce fix sur le play store, reste à voir via la console play store si le nombre de crash descend.

## Informations supplémentaires

Étant donné que l'on créée l'activité de 0, quand on la rouvre elle redémarre de 0 (donc écran d'accueil), ce qui pourra potentiellement altérer aux suggestions de faire retourner l'appli à l'écran auquel on l'a laissé...