### PR TITLE
Fix linter

### DIFF
--- a/src/components/Settings/AccountContainerCard.tsx
+++ b/src/components/Settings/AccountContainerCard.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@react-navigation/native";
 import { LinearGradient } from "expo-linear-gradient";
 import { Pen } from "lucide-react-native";
 import { PressableScale } from "react-native-pressable-scale";
+import React from "react";
 
 const AccountContainerCard = ({ account, onPress }: {
   account: Account

--- a/src/views/account/Attendance/Attendance.tsx
+++ b/src/views/account/Attendance/Attendance.tsx
@@ -19,6 +19,7 @@ import InsetsBottomView from "@/components/Global/InsetsBottomView";
 import { protectScreenComponent } from "@/router/helpers/protected-screen";
 import { Observation } from "@/services/shared/Observation";
 import MissingItem from "@/components/Global/MissingItem";
+import React from "react";
 
 const Attendance: Screen<"Attendance"> = ({ route, navigation }) => {
   const theme = useTheme();

--- a/src/views/account/Restaurant/Menu.tsx
+++ b/src/views/account/Restaurant/Menu.tsx
@@ -216,7 +216,7 @@ const Menu: Screen<"Menu"> = ({ route, navigation }) => {
                     solde={allBalances[selectedIndex].amount}
                     repas={
                       allBalances?.[selectedIndex]?.remaining != null
-                        ? Math.max(0, allBalances[selectedIndex].remaining)
+                        ? Math.max(0, allBalances[selectedIndex].remaining || 0)
                         : null
                     }
                   />

--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -189,7 +189,6 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
           </NativeText>
           {PackageJSON.dependencies["react-native"]  &&
               <NativeText variant="subtitle">
-                {/* @ts-expect-error Le module expo est ajouté aux dépendances au moment du build. */}
                 RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies.expo || PackageJSON.dependencies.expo).split("^")[1]}
               </NativeText>
           }


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Nouvelle PR pour faire passer le linter,  pas "forcément" utile il n'y a que deux erreurs...
## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [ ] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

- `Menu.tsx`: Problème de type `number | null`, utilisation de `0` comme valeur par défaut
- `SettingsAbout.tsx`: Des modifications du package.json ont changé le typage de `PackageJSON`...
- `AccountContianerCard.tsx` & `Attendance.tsx`: Ajout de l'import de `React`, nécessaire pour définir des composants...