### PR TITLE
🚀 Nouveau compte : Ajout des instance depuis les datasets de Papillon

### DIFF
--- a/src/consts/datasets.json
+++ b/src/consts/datasets.json
@@ -2,5 +2,5 @@
   "kofi-supporters": "https://raw.githubusercontent.com/PapillonApp/datasets/main/kofi-supporters.json",
   "changelog": "https://raw.githubusercontent.com/PapillonApp/datasets/main/updates/[version].json",
   "illustrations": "https://raw.githubusercontent.com/PapillonApp/datasets/refs/heads/main/illustrations/index.json",
-  "establishment": "https://raw.githubusercontent.com/PapillonApp/datasets/main/establishment/[postcode].json"
+  "establishment": "https://raw.githubusercontent.com/PapillonApp/datasets/refs/heads/main/establishment/[postcode].json"
 }

--- a/src/consts/datasets.json
+++ b/src/consts/datasets.json
@@ -1,5 +1,6 @@
 {
   "kofi-supporters": "https://raw.githubusercontent.com/PapillonApp/datasets/main/kofi-supporters.json",
   "changelog": "https://raw.githubusercontent.com/PapillonApp/datasets/main/updates/[version].json",
-  "illustrations": "https://raw.githubusercontent.com/PapillonApp/datasets/refs/heads/main/illustrations/index.json"
+  "illustrations": "https://raw.githubusercontent.com/PapillonApp/datasets/refs/heads/main/illustrations/index.json",
+  "establishment": "https://raw.githubusercontent.com/PapillonApp/datasets/main/establishment/[postcode].json"
 }

--- a/src/services/pronote/dataset_geolocation.ts
+++ b/src/services/pronote/dataset_geolocation.ts
@@ -1,7 +1,7 @@
 import pronote from "pawnote";
 import datasets from "../../consts/datasets.json";
 
-const getInstancesFromDataset = async (longitude: number, latitude: number):Promise<pronote.GeolocatedInstance[]> => {
+const getInstancesFromDataset = async (longitude: number, latitude: number): Promise<pronote.GeolocatedInstance[]> => {
   let adress_api_fetch = await fetch(`https://api-adresse.data.gouv.fr/reverse/?lon=${longitude}&lat=${latitude}&limit=1`);
   try {
     let adress_api = await adress_api_fetch.json();
@@ -9,26 +9,53 @@ const getInstancesFromDataset = async (longitude: number, latitude: number):Prom
       return [];
     }
     const postcode = adress_api.features[0].properties.postcode;
+
     let instances_fetch = await fetch(datasets.establishment.replace("[postcode]", postcode));
     try {
       let instances = await instances_fetch.json();
+
+      const calculateHaversineDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
+        const toRadians = (degrees: number) => degrees * (Math.PI / 180);
+        const R = 6371; // Earth's radius in kilometers
+
+        const dLat = toRadians(lat2 - lat1);
+        const dLon = toRadians(lon2 - lon1);
+
+        const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
+            Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c;
+      };
+
       return instances.map((instance: any) => {
-        let distance = Math.sqrt(
-          Math.pow(instance.lat - latitude, 2) + Math.pow(instance.long - longitude, 2)
+        const distance = calculateHaversineDistance(
+          latitude,
+          longitude,
+          instance.lat,
+          instance.long
         );
+
+        console.log("User location:", { latitude, longitude });
+        console.log("Instance location:", { latitude: instance.lat, longitude: instance.long });
+        console.log("Calculated distance:", distance);
+
         return {
           name: instance.name.toUpperCase(),
           url: instance.url,
-          distance: distance,
+          distance,
           longitude: instance.long,
           latitude: instance.lat,
         };
       });
     } catch (error) {
+      console.error("Error fetching instances:", error);
       return [];
     }
   } catch (error) {
-    console.error(error);
+    console.error("Error fetching address:", error);
+    return [];
   }
 };
 

--- a/src/services/pronote/dataset_geolocation.ts
+++ b/src/services/pronote/dataset_geolocation.ts
@@ -8,7 +8,8 @@ const getInstancesFromDataset = async (longitude: number, latitude: number): Pro
     if (adress_api.features.length === 0) {
       return [];
     }
-    const postcode = adress_api.features[0].properties.postcode;
+    let postcode = adress_api.features[0].properties.postcode;
+    postcode = postcode[0] + postcode[1] + "000";
 
     let instances_fetch = await fetch(datasets.establishment.replace("[postcode]", postcode));
     try {

--- a/src/services/pronote/dataset_geolocation.ts
+++ b/src/services/pronote/dataset_geolocation.ts
@@ -1,0 +1,35 @@
+import pronote from "pawnote";
+import datasets from "../../consts/datasets.json";
+
+const getInstancesFromDataset = async (longitude: number, latitude: number):Promise<pronote.GeolocatedInstance[]> => {
+  let adress_api_fetch = await fetch(`https://api-adresse.data.gouv.fr/reverse/?lon=${longitude}&lat=${latitude}&limit=1`);
+  try {
+    let adress_api = await adress_api_fetch.json();
+    if (adress_api.features.length === 0) {
+      return [];
+    }
+    const postcode = adress_api.features[0].properties.postcode;
+    let instances_fetch = await fetch(datasets.establishment.replace("[postcode]", postcode));
+    try {
+      let instances = await instances_fetch.json();
+      return instances.map((instance: any) => {
+        let distance = Math.sqrt(
+          Math.pow(instance.lat - latitude, 2) + Math.pow(instance.long - longitude, 2)
+        );
+        return {
+          name: instance.name.toUpperCase(),
+          url: instance.url,
+          distance: distance,
+          longitude: instance.long,
+          latitude: instance.lat,
+        };
+      });
+    } catch (error) {
+      return [];
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default getInstancesFromDataset;

--- a/src/views/login/pronote/PronoteGeolocation.tsx
+++ b/src/views/login/pronote/PronoteGeolocation.tsx
@@ -70,7 +70,8 @@ const PronoteGeolocation: Screen<"PronoteGeolocation"> = ({ navigation }) => {
         style={[styles.terms_text, { color: colors.text + "59" }]}
       >
         Votre position est nécessaire pour trouver les instances PRONOTE à proximité.
-        Elle n'est pas stockée et ne sera pas partagée.
+        Elle sera envoyée à Pronote et à l'api adresse du gouvernement pour trouver les établissements.
+        Elle n'est pas stockée.
       </Text>
     </SafeAreaView>
   );

--- a/src/views/login/pronote/PronoteInstanceSelector.tsx
+++ b/src/views/login/pronote/PronoteInstanceSelector.tsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useState } from "react";
 import type { Screen } from "@/router/helpers/types";
-import { TextInput, TouchableOpacity, View, StyleSheet, ActivityIndicator, Keyboard, KeyboardEvent } from "react-native";
+import {
+  TextInput,
+  TouchableOpacity,
+  View,
+  StyleSheet,
+  ActivityIndicator,
+  Keyboard,
+  KeyboardEvent,
+  Text
+} from "react-native";
 import pronote from "pawnote";
 import Reanimated, { LinearTransition, FlipInXDown, FadeInUp, FadeOutUp, ZoomIn, ZoomOut, Easing, ZoomInEasyDown } from "react-native-reanimated";
 import determinateAuthenticationView from "@/services/pronote/determinate-authentication-view";
@@ -75,19 +84,37 @@ const PronoteInstanceSelector: Screen<"PronoteInstanceSelector"> = ({
     };
   }, []);
 
-  useEffect(() => {
+
+    useEffect(() => {
     if (params) {
       void async function () {
         const dataset_instances = await getInstancesFromDataset(params.longitude, params.latitude);
         const pronote_instances = await pronote.geolocation(params);
 
         // On calcule la distance entre les instances et l'utilisateur.
-        let instances = pronote_instances.map((instance) => ({
-          ...instance,
-          distance: Math.sqrt(
-            Math.pow(instance.latitude - params.latitude, 2) + Math.pow(instance.longitude - params.longitude, 2)
-          ),
-        }));
+        let instances = pronote_instances.map((instance) => {
+          const toRadians = (degrees: number) => degrees * (Math.PI / 180);
+          const R = 6371; // Earth's radius in kilometers
+
+          const lat1 = toRadians(params.latitude);
+          const lon1 = toRadians(params.longitude);
+          const lat2 = toRadians(instance.latitude);
+          const lon2 = toRadians(instance.longitude);
+
+          const dLat = lat2 - lat1;
+          const dLon = lon2 - lon1;
+
+          const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+              Math.cos(lat1) * Math.cos(lat2) *
+              Math.sin(dLon / 2) * Math.sin(dLon / 2);
+          const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+          const distance = R * c;
+
+          return {
+            ...instance,
+            distance, // Distance in kilometers
+          };
+        });
 
         // On limite à 20 instances.
         instances.splice(20);
@@ -264,7 +291,6 @@ const PronoteInstanceSelector: Screen<"PronoteInstanceSelector"> = ({
                         color={colors.text + "88"}
                       />
                     }
-                    text={instance.name}
                     onPress={async () => {
                       determinateAuthenticationView(
                         instance.url,
@@ -272,7 +298,32 @@ const PronoteInstanceSelector: Screen<"PronoteInstanceSelector"> = ({
                         showAlert
                       );
                     }}
-                  />
+                  >
+                    <Text
+                      style={{
+                        fontSize: 18,
+                        fontFamily: "medium",
+                        width: "100%",
+                        color: colors.text + "88"
+                      }}
+                      numberOfLines={1}
+                      ellipsizeMode="tail"
+                    >
+                      {instance.name}
+                    </Text>
+                    <Text
+                      style={{
+                        fontSize: 15,
+                        fontFamily: "medium",
+                        width: "100%",
+                        color: colors.text + "55",
+                      }}
+                      numberOfLines={1}
+                      ellipsizeMode="tail"
+                    >
+                      {`à ${instance.distance.toFixed(2)}km de toi`}
+                    </Text>
+                  </DuoListPressable>
                 </Reanimated.View>
               ))}
             </Reanimated.View>


### PR DESCRIPTION
# 🚀 Nouveau compte : Ajout des instance depuis les datasets de Papillon
## 💪 Motivation
Nombreux sont les tickets et demande de support indiquant que leurs établissement n'est pas compatible, car 90% des utilisateurs utilise seulement la fonction localisation et recherche de leurs villes pour trouver leur établissement. Papillon utilise la base de données de pronote mais celle-ci dépend en partie du bon vouloir des établissement. En effet, par défaut, les établissement ne sont pas référencé dans la recherche par adresse, ce qui fait que les utilisateurs ne trouve pas leurs établissement.

## ✨ La solution
Papillon utilise des datasets qui sont disponible publiquement sur ce [repo](https://github.com/PapillonApp/datasets). Un nouveau dossier a été crée dans celui-ci [establishment](https://github.com/PapillonApp/datasets/tree/main/establishment), avec dedans, des fichiers json, avec le code postal de la ville la plus proches. (À l'heure ou j'écris, il ne dispose uniquement du 37000 soit Tours). Dans ces fichier nous retrouvons un array d'établissement ayant la structure suivante :

```json
{
    "url": "https://0442770x.index-education.net/pronote",  // URL de l'instance promote
    "name": "CESOL - Tours",                                // Nom de l'établissement
    "long": 0.6560485701484214,                             // Longitude (position de l'établissement)
    "lat": 47.347348484080015                               // Latitude (position de l'établissement)
  }
```

La longitude et la latitude permettent à Papillon de calculer la distance entre l'utilisateur et l'établissement, et permettent de fournir des résultat plus cohérent.

Afin d'obtenir le code postal de la localisation, Papillon utilise l'[api adresse du gouvernement](https://adresse.data.gouv.fr/api-doc/adresse). Celle-ci à des limitations suffisantes pour chaque utilisateurs, et ne conserve pas les données des utilisateurs tout en étant conforme au RGPD. Le service est disponible sur GitHub au nom de [Addok](https://github.com/addok/addok).

## 👀 Quelques modifications supplémentaires
- La distance est désormais calculées par Papillon, ce qui permet d'être beaucoup plus exact contrairement à l'API de pronote.
- Un sous-titre fait sont apparition dans l'écran de sélection de l'établissement, indiquant la distance entre l'utilisateurs et sont établissement.

## 📱 Démo

https://github.com/user-attachments/assets/c82fa6f5-fe54-4854-949f-01f799a02423

_Mon simulateur rame un peu... A quand Expo 52 ? 😭_
