### PR TITLE
Fix de l'affichage des 'repas restants' pour les soldes de cantine

### DIFF
--- a/src/components/Restaurant/RestaurantCard.tsx
+++ b/src/components/Restaurant/RestaurantCard.tsx
@@ -67,7 +67,7 @@ const RestaurantCard: React.FC<RestaurantCardProps> = ({ solde, repas }) => {
         />
       </View>
 
-      {repas !== null && (
+      {repas !== null && repas !== Infinity && (
         <View
           style={{
             flexDirection: "row",

--- a/src/widgets/Components/RestaurantBalance.tsx
+++ b/src/widgets/Components/RestaurantBalance.tsx
@@ -105,7 +105,7 @@ const RestaurantBalanceWidget = forwardRef(({
             paddingLeft: 6,
           }}
         />
-        {currentBalance?.remaining !== undefined && currentBalance?.remaining !== null && (
+        {currentBalance?.remaining !== undefined && currentBalance?.remaining !== null && currentBalance.remaining !== Infinity && (
           <View style={{
             flexDirection: "row",
             alignItems: "center",


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Avec ce fix, lorsque le nombre de repas restants vaut 'Infinity' car le prix d'un repas est fixé à 0 (typiquement dans mon cas je suis au forfait donc cela survient), la "carte" avec le nombre de repas restants, alors inutile, n'est plus affichée. 

## Informations supplémentaires

Capture d'écran du problème en question:

![Capture d’écran du 2024-12-23 19-51-06](https://github.com/user-attachments/assets/100c353e-b52c-4ddd-ac50-8e01bdf40e92)

