### PR TITLE
chore(deps): update `turboself-api` to `2.1.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "reanimated-color-picker": "^3.0.4",
     "scolengo-api": "^3.0.5",
     "text-encoding": "^0.7.0",
-    "turboself-api": "^2.1.6",
+    "turboself-api": "^2.1.7",
     "zustand": "^4.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Mise à jour de `turboself-api` vers la version `2.1.7` afin de corriger le bug des jours de réservation "dupliqués". (bug rapporté sur Discord n'ayant pas d'issue).
