### PR TITLE
fix(NativeComponents): Adaptation du style pour une application également sur Android

### DIFF
--- a/src/components/Global/NativeComponents.tsx
+++ b/src/components/Global/NativeComponents.tsx
@@ -229,6 +229,13 @@ export const NativeItem: React.FC<NativeItemProps> = ({
       entering={entering && entering}
       exiting={exiting && exiting}
       pointerEvents={pointerEvents}
+      style={[
+        item_styles.item,
+        style,
+        disabled && {
+          opacity: 0.5,
+        },
+      ]}
     >
       <NativePressable
         onPress={!disabled ? onPress : () => {}}
@@ -238,13 +245,8 @@ export const NativeItem: React.FC<NativeItemProps> = ({
         onTouchEnd={onTouchEnd}
         androidStyle={androidStyle}
         style={({ pressed }) => [
-          item_styles.item,
           onPress && {
             backgroundColor: pressed && !disabled ? colors.text + "12" : "transparent",
-          },
-          style,
-          disabled && {
-            opacity: 0.5,
           },
         ]}
       >


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Le style qui était présent dans `<NativePressable>` s'appliquait uniquement sur iOS, d'où le non affichage des boutons grisés sur Android
Pour y remédier, ça a été déplacé dans `<Reanimated.View>` pour que le style soit appliqué sur iOS **ET** Android

## Issue en lien

- Close #563 

## Informations supplémentaires

![1735939379822](https://github.com/user-attachments/assets/aa8e1628-4d5c-4121-a96c-15a560779830)
