### PR TITLE
Update SettingsAbout.tsx

### DIFF
--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -203,7 +203,6 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
               <NativeText variant="subtitle">
                 RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies["expo"] || PackageJSON.dependencies["expo"]).split("~")[1]}
               </NativeText>
-          }
         </NativeItem>
       </NativeList>
 

--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -200,7 +200,6 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
           <NativeText variant="title">
             Version des dépendances
           </NativeText>
-          {PackageJSON.dependencies["react-native"]  &&
               <NativeText variant="subtitle">
                 RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies["expo"] || PackageJSON.dependencies["expo"]).split("~")[1]}
               </NativeText>

--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -202,7 +202,7 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
           </NativeText>
           {PackageJSON.dependencies["react-native"]  &&
               <NativeText variant="subtitle">
-                RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies.expo || PackageJSON.dependencies.expo).split("^")[1]}
+                RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies["expo"] || PackageJSON.dependencies["expo"]).split("~")[1]}
               </NativeText>
           }
         </NativeItem>

--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -201,7 +201,8 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
             Version des dépendances
           </NativeText>
               <NativeText variant="subtitle">
-                RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies["expo"] || PackageJSON.dependencies["expo"]).split("~")[1]}
+                RN : {PackageJSON.dependencies["react-native"].split("^")[1]} | Expo : {(PackageJSON.devDependencies["expo"] || PackageJSON.dependencies["expo"]).split(/[~^]/)[1] || (PackageJSON.devDependencies["expo"] || PackageJSON.dependencies["expo"])}
+</NativeText>
               </NativeText>
         </NativeItem>
       </NativeList>


### PR DESCRIPTION
Ajustement de la méthode de récupération de version d’expo, car sinon, ça n’était pas afficher dans l’application a cause de l’utilisation de ~ dans package.json alors que ^ était utilisé ici.

# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [ ] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [X] Vous respectez les conventions de codage et de nommage du projet
- [X] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [X] Cette pull request **n'est pas un duplicata** d'une autre
- [X] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [X] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [X] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [X] Les détails des changements ont été décrits ci-dessous
- [X] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Décrivez les modifications que vous avez effectuées.
> Passage de "^" à "~" lors de la récupération de la version d’expo.
> Utilisation du même code que pour la récupération de RN permettant d’être sûr que ça marchera

## Informations supplémentaires

Ajoutez ici toute information supplémentaire si nécessaire.
> Sur la 7.7, la version d’Expo n’est pas/plus affichée