### PR TITLE
Suppression ouverture Logs lors de l’appuie sur version dépendances.

### DIFF
--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -193,6 +193,7 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
             ver. {AppJSON.expo.version} {Constants.appOwnership === "expo" ? "(Expo Go)" : ""} {__DEV__ ? "(debug)" : ""}
           </NativeText>
         </NativeItem>
+        <NativeItem>
           <NativeText variant="title">
             Version des dépendances
           </NativeText>

--- a/src/views/settings/SettingsAbout.tsx
+++ b/src/views/settings/SettingsAbout.tsx
@@ -193,10 +193,6 @@ const SettingsAbout: Screen<"SettingsAbout"> = ({ navigation }) => {
             ver. {AppJSON.expo.version} {Constants.appOwnership === "expo" ? "(Expo Go)" : ""} {__DEV__ ? "(debug)" : ""}
           </NativeText>
         </NativeItem>
-        <NativeItem
-          onPress={() => navigation.navigate("SettingsDevLogs")}
-          chevron={false}
-        >
           <NativeText variant="title">
             Version des dépendances
           </NativeText>


### PR DESCRIPTION
Suppression de l’ouverture des Logs lors de l’appuie sur la version des dépendances dans le menu à propos des réglages, car, c’est déjà ouvert quand on appuie plusieurs fois sur la version d’application.

# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [ ] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [X] Vous respectez les conventions de codage et de nommage du projet
- [X] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [X] Cette pull request **n'est pas un duplicata** d'une autre
- [X] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [X] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [X] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [X] Les détails des changements ont été décrits ci-dessous
- [X] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Décrivez les modifications que vous avez effectuées.

Suppression de l’ouverture des Logs lors de l’appui sur les versions des dépendances, car c’est déjà le cas quand on appuie plusieurs fois sur la version de l’application

## Informations supplémentaires

Ajoutez ici toute information supplémentaire si nécessaire.

j’ai pas pu tester le build mais j’enlève juste un bouton donc je pense ça devrait pas poser problème.
Voici une vidéo de l’application actuel :

https://github.com/user-attachments/assets/fcc44eb9-0840-4184-b641-4eb81eb2624d

J’ai découvert le bug en montrant à un pote que j’étais sur son téléphone TT
