### PR TITLE
[App crash] fix(grades): if no coefficient is returned, set to 1

### DIFF
--- a/src/services/ecoledirecte/grades.ts
+++ b/src/services/ecoledirecte/grades.ts
@@ -122,7 +122,7 @@ export const getGradesAndAverages = async (
         isOptional: g.isOptional,
 
         outOf: getGradeValue(g.outOf),
-        coefficient: g.coefficient,
+        coefficient: g.coefficient ?? 1,
 
         student: decodeGradeValue(g.value),
         average: decodeGradeValue(g.average),

--- a/src/services/pronote/grades.ts
+++ b/src/services/pronote/grades.ts
@@ -105,7 +105,7 @@ export const getGradesAndAverages = async (
     isOptional: g.isOptional,
 
     outOf: decodeGradeValue(g.outOf),
-    coefficient: g.coefficient,
+    coefficient: g.coefficient ?? 1,
 
     student: decodeGradeValue(g.value),
     average: decodeGradeValue(g.average),

--- a/src/services/skolengo/data/grades.ts
+++ b/src/services/skolengo/data/grades.ts
@@ -65,7 +65,7 @@ export const getGradesAndAverages = async (account: SkolengoAccount, periodName:
     isOptional: false,
 
     outOf: decodeGradeNumber(g.scale),
-    coefficient: g.coefficient || 1,
+    coefficient: g.coefficient ?? 1,
 
     student: decodeGradeNumber(g.evaluationResult.mark),
     average: decodeGradeNumber(g.average),


### PR DESCRIPTION
> [!CAUTION]
> Lorsque les coefficients ne sont pas retournés par Pronote, cela cause un crash de l'application. Cette PR résout ce problème.

 
## Checklist

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelog

Pronote has recently implemented the ability to hide grade coefficients. This prevents calculation of the average, and causes a crash when displaying the average or grade details.

This significantly skews the calculation of the overall average in the case of grades with coefficients other than 1, but there are no other solutions.

- If the coefficient isn't returned, set to 1
- The same applies to Ecole Direct, just in case.
- If the coefficient in Skolengo is 0, take it into account rather than setting it to 1. (`||` --> `??`)

<details><summary>No coefficient displayed on Pronote</summary>
<p>

![image](https://github.com/user-attachments/assets/06747950-b6b3-4c6d-bfe3-8dcd1b3aef6c)

</p>
</details> 