### PR TITLE
Fix redirection issue on Accueil page

### DIFF
--- a/src/components/Home/RedirectButton.tsx
+++ b/src/components/Home/RedirectButton.tsx
@@ -9,17 +9,23 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 interface RedirectButtonProps {
   navigation: NativeStackNavigationProp<RouteParameters, keyof RouteParameters>
   redirect: keyof RouteParameters
+  date?: Date
 }
 
-const RedirectButton: React.FC<RedirectButtonProps> = ({ navigation, redirect }) => {
+const RedirectButton: React.FC<RedirectButtonProps> = ({ navigation, redirect, date }) => {
   const theme = useTheme();
   const { colors } = theme;
 
+  const handlePress = () => {
+    if (date) {
+      navigation.navigate(redirect, { date });
+    } else {
+      navigation.navigate(redirect);
+    }
+  };
+
   return (
-    <TouchableOpacity
-      // @ts-expect-error : on ne prend pas le state des routes en compte ici.
-      onPress={() => navigation.navigate(redirect)}
-    >
+    <TouchableOpacity onPress={handlePress}>
       <View
         style={{
           flexDirection: "row",

--- a/src/views/account/Home/Elements/TimetableElement.tsx
+++ b/src/views/account/Home/Elements/TimetableElement.tsx
@@ -224,12 +224,17 @@ const TimetableElement: React.FC<TimetableElementProps> = ({ onImportance }) => 
 
   const label = nextCourses.length > 0 ? getLabelForNextCourse(nextCourses[0].startTimestamp) : "";
 
+  const handleRedirect = () => {
+    const nextCourseDate = new Date(nextCourses[0].startTimestamp);
+    PapillonNavigation.current.navigate("Lessons", { date: nextCourseDate });
+  };
+
   return (
     <>
       <NativeListHeader
         animated
         label={label}
-        trailing={<RedirectButton navigation={PapillonNavigation.current} redirect="Lessons" />}
+        trailing={<RedirectButton navigation={PapillonNavigation.current} redirect="Lessons" onPress={handleRedirect} />}
       />
       <Reanimated.View layout={LinearTransition} style={{ marginTop: 24, gap: 10 }}>
         {nextCourses.map((course, index) => (

--- a/src/views/account/Lessons/Lessons.tsx
+++ b/src/views/account/Lessons/Lessons.tsx
@@ -280,6 +280,12 @@ const Lessons: Screen<"Lessons"> = ({ route, navigation }) => {
     }, 0);
   };
 
+  useEffect(() => {
+    if (route.params?.date) {
+      onDateSelect(new Date(route.params.date));
+    }
+  }, [route.params?.date]);
+
   return (
     <View style={{ flex: 1 }}>
       <PapillonModernHeader outsideNav={outsideNav}>


### PR DESCRIPTION
Fix the redirection issue on the 'Accueil' page to the 'Cours' page with the correct date.

* **TimetableElement.tsx**
  - Add `handleRedirect` function to pass the correct date to the 'Cours' page.
  - Update `RedirectButton` component to use `handleRedirect` function.

* **RedirectButton.tsx**
  - Add `date` prop to `RedirectButtonProps` interface.
  - Update `handlePress` function to include the date in the navigation parameters if provided.

* **Lessons.tsx**
  - Add `useEffect` to reset the date state to the passed date parameter when navigating back to the 'Cours' page.

