### PR TITLE
fix(router): Plantage des paramètres sur Android

### DIFF
--- a/src/router/screens/index.ts
+++ b/src/router/screens/index.ts
@@ -14,7 +14,7 @@ export default [
 
   createScreen("SettingStack", SettingsScreen, {
     headerShown: false,
-    presentation: "formSheet",
+    presentation: Platform.OS === "android" ? "modal" : "formSheet",
     animation: Platform.OS === "android" ? "slide_from_right" : "default",
     animationDuration: 100,
     sheetCornerRadius: 24,


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Depuis que la presentation de `SettingsStack` a été changé, l'application plantait avec l'erreur suivante (build dev Android) : FragmentManager is already executing transactions

Donc, **sur Android uniquement**, la presentation a été définie sur `modal`

## Informations supplémentaires

undefined