### PR TITLE
Correction des crashs sur la page des notes

### DIFF
--- a/src/views/account/Grades/Grades.tsx
+++ b/src/views/account/Grades/Grades.tsx
@@ -253,7 +253,7 @@ const Grades: Screen<"Grades"> = ({ route, navigation }) => {
             )}
 
             {grades[selectedPeriod] &&
-							grades[selectedPeriod].length > 1 && (
+							grades[selectedPeriod].filter((grade) => grade.student.value !== null && !isNaN(grade.student.value)).length > 1 && (
               <Reanimated.View
                 layout={animPapillon(LinearTransition)}
                 entering={FadeInUp.duration(200)}

--- a/src/views/account/Grades/Graph/GradesAverage.tsx
+++ b/src/views/account/Grades/Graph/GradesAverage.tsx
@@ -109,8 +109,8 @@ const GradesAverageGraph: React.FC<GradesAverageGraphProps> = ({
     hst = hst.filter((p) => isNaN(p.value) === false);
 
     graphRef.current?.updateData({
-      xAxis: hst.map((p, i) => new Date(p.date).getTime()),
-      yAxis: hst.map((p) => p.value),
+      xAxis: hst.length > 0 ? hst.map((p, i) => new Date(p.date).getTime()) : [Date.now()],
+      yAxis: hst.length > 0 ? hst.map((p) => p.value) : [10],
     });
   }, [grades, account.instance]);
 


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

J'ai tenté de résoudre les crash de l'issue #758 , en filtrant l'historique des notes retirant les NaN, si l'utilisateur n'a pas d'autres notes valident alors ça donne une table vide, il y a donc ici une vérification et une valeur par défaut pour éviter ça. En plus de ça il y a un check pour vérifier qu'il y a des notes valident avant d'afficher le graphique. (faut juste tester si ça fonctionne, j'avais pas cette situation chez moi donc j'ai pas pu full test)

## Informations supplémentaires

close #758 