### PR TITLE
fix: utilisation de `date-fns` dans le formattage des dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7978,6 +7978,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"

--- a/src/services/ecoledirecte/format-date.ts
+++ b/src/services/ecoledirecte/format-date.ts
@@ -1,7 +1,5 @@
-export const formatDate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, "0"); // months are 0-indexed, so +1
-  const day = date.getDate().toString().padStart(2, "0");
+import { format } from "date-fns";
 
-  return `${year}-${month}-${day}`;
+export const formatDate = (date: Date): string => {
+  return format(date, "yyyy-MM-dd");
 };

--- a/src/utils/format/DateHelper.ts
+++ b/src/utils/format/DateHelper.ts
@@ -1,72 +1,28 @@
-export const timestampToString = (timestamp: number) => {
+import {
+  formatDistanceToNow,
+  isToday,
+  isTomorrow,
+  isYesterday,
+} from "date-fns";
+import { fr } from "date-fns/locale";
 
+export const timestampToString = (timestamp: number) => {
   if (!timestamp || Number.isNaN(timestamp)) {
     return "Date invalide";
   }
 
   const date = new Date(timestamp);
-  const today = new Date();
   if (Number.isNaN(date.getTime())) {
     return "Date invalide";
   }
 
-  today.setHours(0, 0, 0, 0);
-  date.setHours(0, 0, 0, 0);
-
-  let formattedDate: string;
-
-  let dateDifference = [
-    date.getFullYear() - today.getFullYear(),
-    date.getMonth() - today.getMonth(),
-    date.getDate() - today.getDate(),
-  ];
-
-  let yearDifference = dateDifference[0];
-  if (dateDifference[1] < 0 || (dateDifference[1] === 0 && dateDifference[2] < 0)) {
-    yearDifference--;
-  } else if (dateDifference[1] > 0 || (dateDifference[1] === 0 && dateDifference[2] > 0)) {
-    yearDifference++;
-  }
-  let monthDifference = dateDifference[0] * 12 + dateDifference[1];
-
-  if (dateDifference[2] < 0) {
-    monthDifference--;
-  } else if (dateDifference[2] > 0) {
-    monthDifference++;
-  }
-  let dayDifference = Math.round(
-    (date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
-  );
-
-  if (yearDifference < 0) {
-    formattedDate = `Il y a ${Math.abs(yearDifference)} an${
-      Math.abs(yearDifference) > 1 ? "s" : ""
-    }`;
-  } else if (yearDifference > 0) {
-    formattedDate = `Dans ${yearDifference} an${yearDifference > 1 ? "s" : ""}`;
+  if (isToday(date)) {
+    return "Aujourd'hui";
+  } else if (isTomorrow(date)) {
+    return "Demain";
+  } else if (isYesterday(date)) {
+    return "Hier";
   } else {
-    if (monthDifference < 0) {
-      formattedDate = `Il y a ${Math.abs(monthDifference)} mois`;
-    } else if (monthDifference > 0) {
-      formattedDate = `Dans ${monthDifference} mois`;
-    } else {
-      if (dayDifference < -2) {
-        formattedDate = `Il y a ${Math.abs(dayDifference)} jours`;
-      } else if (dayDifference === -2) {
-        formattedDate = "Avant-hier";
-      } else if (dayDifference === -1) {
-        formattedDate = "Hier";
-      } else if (dayDifference === 0) {
-        formattedDate = "Aujourd'hui";
-      } else if (dayDifference === 1) {
-        formattedDate = "Demain";
-      } else if (dayDifference === 2) {
-        formattedDate = "Après-demain";
-      } else {
-        formattedDate = `Dans ${dayDifference} jours`;
-      }
-    }
+    return formatDistanceToNow(date, { addSuffix: true, locale: fr });
   }
-
-  return formattedDate;
 };

--- a/src/utils/format/attendance_time.ts
+++ b/src/utils/format/attendance_time.ts
@@ -1,3 +1,5 @@
+import { differenceInHours, differenceInMinutes } from "date-fns";
+
 const leadingZero = (num: number) => {
   return num < 10 ? `0${num}` : num;
 };
@@ -5,12 +7,15 @@ const leadingZero = (num: number) => {
 const getAbsenceTime = (fromTimestamp: number, toTimestamp: number) => {
   const from = new Date(fromTimestamp);
   const to = new Date(toTimestamp);
-  const diff = to.getTime() - from.getTime();
+
+  const hours = differenceInHours(to, from);
+  const minutes = differenceInMinutes(to, from) % 60;
+
   return {
-    diff: diff,
-    hours: Math.floor(diff / 1000 / 60 / 60),
-    withMinutes: leadingZero(Math.floor(diff / 1000 / 60) % 60),
-    minutes: Math.floor(diff / 1000 / 60),
+    diff: to.getTime() - from.getTime(),
+    hours,
+    withMinutes: leadingZero(minutes),
+    minutes: differenceInMinutes(to, from),
   };
 };
 

--- a/src/utils/format/format_date.ts
+++ b/src/utils/format/format_date.ts
@@ -1,7 +1,0 @@
-/**
- * @example
- * dateAsShortString(new Date('2021-12-31')) // '31/12/2021'
- */
-export const dateAsShortString = (date: Date): string => {
-  return date.toLocaleDateString("en-GB");
-};

--- a/src/utils/format/format_date_complets.ts
+++ b/src/utils/format/format_date_complets.ts
@@ -1,23 +1,14 @@
-function formatDate (date: string): string {
-  const currentDate = new Date();
-  const messageDate = new Date(date);
-  const diffTime = Math.abs(currentDate.getTime() - messageDate.getTime());
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-  const diffMonths = Math.floor(diffDays / 30);
+import { formatDistanceToNow } from "date-fns";
+import { fr } from "date-fns/locale";
 
-  if (diffDays < 1) {
-    return "Aujourd'hui";
-  } else if (diffDays < 30) {
-    return `Il y a ${diffDays} jour${diffDays !== 1 ? "s" : ""}`;
-  } else if (diffMonths === 1) {
-    return "Il y a 1 mois";
-  } else {
-    return `Le ${messageDate.getDay().toString().padStart(2, "0")}/${(
-      messageDate.getMonth() + 1
-    )
-      .toString()
-      .padStart(2, "0")}/${messageDate.getFullYear()}`;
+function formatDate (date: string): string {
+  const messageDate = new Date(date);
+
+  if (Number.isNaN(messageDate.getTime())) {
+    return "Date invalide";
   }
+
+  return formatDistanceToNow(messageDate, { addSuffix: true, locale: fr });
 }
 
 export default formatDate;


### PR DESCRIPTION
# 🚀 Nouvelle Pull Request

Proposez vos modifications pour améliorer Papillon

## Informations importantes

Merci de vous référer à la documentation sur la contribution si vous avez des questions à propos des pull requests (https://gitbook.getpapillon.xyz/organisation/outils-internes/github)

## Checklist d'avant pull request

Veuillez cocher toutes les cases applicables en remplaçant [ ] par [x].

- [x] Vous avez testé de build le projet avec vos modifications et ce build **a réussi**
- [x] Vous respectez les conventions de codage et de nommage du projet
- [x] Vous utilisez la **tabulation** pour l'indentation afin de maintenir un code lisible
- [x] Cette pull request **n'est pas un duplicata** d'une autre
- [x] Cette pull request est prête à être **revue** (review) et **fusionnée** (merge)
- [x] Il n'y a pas de **`TODO`** (aka des annotations pour du code manquant) dans vos modifications
- [x] Il n'y a pas **d'erreurs de langue** dans votre code (grammaire, vocabulaire, conjugaison, orthographe)
- [x] Les détails des changements ont été décrits ci-dessous
- [x] Cette pull-request n'est pas une **"breaking-change"** (des modifications qui vont entraîner la modification du fonctionnement de certaines fonctionnalités déjà existantes)

## Changelogs proposés

Depuis #750, les devoirs pour le lendemain sont affichés "Dans 1 an". Pour fix :

- Utilisation de `date-fns` pour fix ce problème => améliore les performances (moins de calculs) et la qualité du code

Et j'en ai profité pour :

- Utilisation de `date-fns` dans la majorité des utils qui formattent les dates
- Suppression du fichier `format_date` non utilisé

## Issue en lien

- Closes #766 
- Closes #767 
- Closes #769 

## Informations supplémentaires

| Avant | Après |
|--------|--------|
| ![1741559016456](https://github.com/user-attachments/assets/ab86fd66-355b-4305-9f21-6103d7684481) | ![1741559016441](https://github.com/user-attachments/assets/300bc410-baba-4e09-bd0b-d67f773368fc) |
| ![1741559016453](https://github.com/user-attachments/assets/75ec4624-589b-4203-af93-e436aaaa32a4) | ![1741559016447](https://github.com/user-attachments/assets/49f7b042-54c9-4c36-8b11-928b96483769) | 