### PR TITLE
typo(changelog)/change no update note sentence

### DIFF
--- a/src/views/welcome/ChangelogScreen.tsx
+++ b/src/views/welcome/ChangelogScreen.tsx
@@ -143,7 +143,7 @@ const ChangelogScreen: Screen<"ChangelogScreen"> = ({ route, navigation }) => {
               Impossible de trouver les notes de mise à jour
             </NativeText>
             <NativeText variant="subtitle">
-              Tu es peut-être hors-ligne ou alors une erreur est survenue...
+              Tu es peut-être hors-ligne ou la note n'a pas encore été publiée...
             </NativeText>
           </NativeItem>
         </NativeList>


### PR DESCRIPTION
## Changelogs proposés

Nouvelle PR ultra-simple ;)
Changement de la phrase lorsque la note de mise à jour n'est pas disponible ; dans la majorité des cas elle n'est juste pas publiée ! J'ai vu pas mal de messages à ce sujet sur le discord, reportant l'erreur, alors cette nouvelle formulation enlève toute ambiguïté.

`Tu es peut-être hors-ligne ou alors une erreur est survenue...` --> `Tu es peut-être hors-ligne ou la note n'a pas encore été publiée...`