### PR TITLE
Ajout de hier, aujourd’hui, demain

### DIFF
--- a/src/utils/format/format_date_complets.ts
+++ b/src/utils/format/format_date_complets.ts
@@ -1,4 +1,4 @@
-import { formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow, isToday } from "date-fns";
 import { fr } from "date-fns/locale";
 
 function formatDate (date: string): string {

--- a/src/utils/format/format_date_complets.ts
+++ b/src/utils/format/format_date_complets.ts
@@ -7,8 +7,20 @@ function formatDate (date: string): string {
   if (Number.isNaN(messageDate.getTime())) {
     return "Date invalide";
   }
+  let formattedDate = formatDistanceToNow(messageDate, { addSuffix: true, locale: fr });
 
-  return formatDistanceToNow(messageDate, { addSuffix: true, locale: fr });
+  if (formattedDate === "dans 1 jour") {
+    return "demain";
+  }
+  if (formattedDate === "il y a 1 jour") {
+    return "hier";
+  }
+
+  if (isToday(messageDate)) {
+    return "aujourd’hui";
+  }
+
+  return formattedDate;
 }
 
 export default formatDate;

--- a/src/utils/format/format_date_complets.ts
+++ b/src/utils/format/format_date_complets.ts
@@ -1,4 +1,4 @@
-import { formatDistanceToNow, isToday } from "date-fns";
+import { formatDistanceToNow, isYesterday, isToday, isTomorrow } from "date-fns";
 import { fr } from "date-fns/locale";
 
 function formatDate (date: string): string {
@@ -9,15 +9,16 @@ function formatDate (date: string): string {
   }
   let formattedDate = formatDistanceToNow(messageDate, { addSuffix: true, locale: fr });
 
-  if (formattedDate === "dans 1 jour") {
-    return "demain";
-  }
-  if (formattedDate === "il y a 1 jour") {
+  if (isYesterday(messageDate)) {
     return "hier";
   }
 
   if (isToday(messageDate)) {
     return "aujourd’hui";
+  }
+
+  if (isTomorrow(messageDate)) {
+    return "demain";
   }
 
   return formattedDate;


### PR DESCRIPTION
Afin d'éviter les "il y'a 1 jour" "dans 1 jour" "il y a environ 14 heures"

# ✨ Nouvelle Pull Request

Merci de contribuer à l'amélioration de Papillon !

Tu te poses des questions sur les pull requests (PR) ? Une documentation a spécialement été créée ici => https://gitbook.getpapillon.xyz/organisation/outils-internes/github

## Avant toute chose...

Tu t'assures avoir respecté les points suivants (_en rajoutant un `x` dans les crochets_) :

- [ ] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [X] 🗣️ J'utilise le **langage informel** (tutoiement)
- [X] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [X] 📝 J'ai fait **une description des changement effectués** ci-dessous


## Résumé des changements effectués

_Les modifications_

J’ai ajusté le code pour renvoyer automatiquement hier, aujourd’hui et demain au lieu de il y a 1 jour, il y a environ 14 heures (correspondant à ce matin minuit) et dans 1 jour
Comme il y’a sur ces captures :

![IMG_5287](https://github.com/user-attachments/assets/8c5bb81d-dc7c-4968-87f8-7955de868f36)
![IMG_5288](https://github.com/user-attachments/assets/76714e69-35aa-42d4-a040-d6f1bf0a29a8)
![IMG_5289](https://github.com/user-attachments/assets/b0c5b223-9ebf-42e7-9d59-4b8c39548ed0)

## Capture(s) d'écran (pour rendre le test de ta PR rapide)

_Le(s) capture(s) d'écran_

## Issue(s) en rapport

> [!NOTE]
>
> Cette section te permet de référencer des issues en lien avec ta PR. Pour que les issues soient fermées automatiquement au merge, utilise les "[closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)" de Github (exemples ci-dessous).

- Closed #815

_S'il y en a plusieurs, continuer à les lister_

- Closed #(_le numéro de l'issue_)

