### PR TITLE
Ne plus afficher le "Modal Grabber" sur Android

### DIFF
--- a/src/components/Global/PapillonModernHeader.tsx
+++ b/src/components/Global/PapillonModernHeader.tsx
@@ -126,7 +126,7 @@ const LinearGradientModernHeader: React.FC<ModernHeaderProps> = ({ children, out
         {children}
       </Reanimated.View>
 
-      {outsideNav &&
+      {outsideNav && Platform.OS ==  "ios" &&
         <View
           style={{
             position: "absolute",


### PR DESCRIPTION
# ✨ Nouvelle Pull Request

Merci de contribuer à l'amélioration de Papillon !

Tu te poses des questions sur les pull requests (PR) ? Une documentation a spécialement été créée ici => https://gitbook.getpapillon.xyz/organisation/outils-internes/github

## Avant toute chose...

Tu t'assures avoir respecté les points suivants (_en rajoutant un `x` dans les crochets_) :

- [x] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [x] 🗣️ J'utilise le **langage informel** (tutoiement)
- [x] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [x] 📝 J'ai fait **une description des changement effectués** ci-dessous

## Résumé des changements effectués

Etant donné que sur Android, la navigation par gestes n'est pas supportée, il est inutile d'afficher un "Modal Grabber" en haut des pages "modal", puisqu'il n'est pas fonctionnel. Par conséquent, cette PR permet d'afficher le "Modal Grabber" uniquement sur IOS où la navigation par gestes est supportée.

## Issue(s) en rapport

- Closed #850 
