### PR TITLE
fix: Correction de divers bugs sur la page "Détail de la carte"

### DIFF
--- a/src/components/Global/PapillonHeader.tsx
+++ b/src/components/Global/PapillonHeader.tsx
@@ -12,7 +12,8 @@ import { PapillonModernHeader } from "./PapillonModernHeader";
 interface PapillonHeaderProps {
   children?: React.ReactNode
   route: RouteProp<RouteParameters, keyof RouteParameters>
-  navigation: NativeStackNavigationProp<RouteParameters, keyof RouteParameters>
+  navigation: NativeStackNavigationProp<RouteParameters, keyof RouteParameters>,
+  title?: string
 }
 
 interface PapillonHeaderInsetHeightProps {
@@ -22,7 +23,8 @@ interface PapillonHeaderInsetHeightProps {
 const PapillonHeader: React.FC<PapillonHeaderProps> = ({
   children,
   route,
-  navigation
+  navigation,
+  title
 }) => {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
@@ -39,6 +41,7 @@ const PapillonHeader: React.FC<PapillonHeaderProps> = ({
             display: "flex",
             flexDirection: "row",
             justifyContent: "space-between",
+            alignItems: "center"
           }}
         >
           {route.params?.outsideNav && Platform.OS !== "ios" && (
@@ -56,6 +59,7 @@ const PapillonHeader: React.FC<PapillonHeaderProps> = ({
             route={route}
             navigation={navigation}
             style={{ paddingHorizontal: 0 }}
+            title={title}
           />
 
           <View
@@ -65,7 +69,6 @@ const PapillonHeader: React.FC<PapillonHeaderProps> = ({
               flexDirection: "row",
               justifyContent: "flex-end",
               alignItems: "center",
-              marginRight: Platform.OS !== "ios" ? -16 : 0,
             }}
           >
             {children}

--- a/src/components/Global/TabAnimatedTitle.tsx
+++ b/src/components/Global/TabAnimatedTitle.tsx
@@ -10,16 +10,18 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 interface TabAnimatedTitleProps {
   route: RouteProp<RouteParameters, keyof RouteParameters>;
   navigation?: NativeStackNavigationProp<RouteParameters, keyof RouteParameters>;
-  style?: StyleProp<ViewStyle>
+  style?: StyleProp<ViewStyle>,
+  title?: string
 }
 
-const TabAnimatedTitle = ({ route, navigation }: TabAnimatedTitleProps) => {
+const TabAnimatedTitle = ({ route, navigation, title }: TabAnimatedTitleProps) => {
   return {
     headerTitle: () => <View />,
     headerLeft: () => (
       <TabAnimatedTitleLeft
         route={route}
         navigation={navigation}
+        title={title}
       />
     ),
     headerRight: () => (
@@ -32,21 +34,24 @@ const TabAnimatedTitle = ({ route, navigation }: TabAnimatedTitleProps) => {
   };
 };
 
-const TabAnimatedTitleLeft = ({ route, style }: TabAnimatedTitleProps) => {
+const TabAnimatedTitleLeft = ({ route, style, title }: TabAnimatedTitleProps) => {
   const theme = useTheme();
+  const icon = defaultTabs.find((curr) => curr.tab === route.name)?.icon;
 
   return (
     <View style={[styles.headerLeft, !route.params?.outsideNav && { paddingHorizontal: 16 }, style]}>
-      <LottieView
-        source={defaultTabs.find((curr) => curr.tab === route.name)?.icon}
-        autoPlay
-        loop={false}
-        style={styles.lottieView}
-        colorFilters={[{ keypath: "*", color: theme.colors.text }]}
-      />
+      {icon &&
+        <LottieView
+          source={icon}
+          autoPlay
+          loop={false}
+          style={styles.lottieView}
+          colorFilters={[{ keypath: "*", color: theme.colors.text }]}
+        />
+      }
 
       <Text style={[styles.headerTitle, { color: theme.colors.text }]} numberOfLines={1}>
-        {defaultTabs.find((curr) => curr.tab === route.name)?.label}
+        {defaultTabs.find((curr) => curr.tab === route.name)?.label ?? title}
       </Text>
     </View>
   );

--- a/src/router/helpers/types.ts
+++ b/src/router/helpers/types.ts
@@ -156,6 +156,7 @@ export type RouteParameters = {
   };
   RestaurantCardDetail: {
     card: ServiceCard;
+    outsideNav?: boolean;
   };
   RestaurantPaymentSuccess: {
     card: ServiceCard;

--- a/src/router/screens/views/index.ts
+++ b/src/router/screens/views/index.ts
@@ -41,11 +41,8 @@ export default [
     presentation: "modal",
   }),
   createScreen("RestaurantCardDetail", RestaurantCardDetail, {
-    headerTitle: "Détail de la carte",
+    headerShown: false,
     presentation: Platform.OS == "android" ? "modal" : "formSheet",
-    headerShown: true,
-    headerLargeTitle: true,
-    headerTransparent: Platform.OS !== "android",
     sheetCornerRadius: 16,
     sheetGrabberVisible: true,
     sheetExpandsWhenScrolledToEdge: true,

--- a/src/views/account/Restaurant/Menu.tsx
+++ b/src/views/account/Restaurant/Menu.tsx
@@ -407,7 +407,7 @@ const Menu: Screen<"Menu"> = ({ route, navigation }) => {
                       key={index}
                       card={card}
                       onPress={() => {
-                        navigation.navigate("RestaurantCardDetail", { card });
+                        navigation.navigate("RestaurantCardDetail", { card, outsideNav: true });
                       }}
                     />
                   </Reanimated.View>

--- a/src/views/account/Restaurant/Modals/CardDetail.tsx
+++ b/src/views/account/Restaurant/Modals/CardDetail.tsx
@@ -12,14 +12,15 @@ import InsetsBottomView from "@/components/Global/InsetsBottomView";
 import { PressableScale } from "react-native-pressable-scale";
 import { useAccounts, useCurrentAccount } from "@/stores/account";
 import { AccountService, ExternalAccount } from "@/stores/account/types";
-import { ExternalLink, MoreHorizontal, QrCode, Trash2 } from "lucide-react-native";
+import { ExternalLink, MoreVertical, QrCode, Trash2 } from "lucide-react-native";
 import { balanceFromExternal } from "@/services/balance";
 import { reservationHistoryFromExternal } from "@/services/reservation-history";
 import { Screen } from "@/router/helpers/types";
 import { LinearGradient } from "expo-linear-gradient";
-import { TouchableOpacity } from "react-native-gesture-handler";
-import PapillonPicker from "@/components/Global/PapillonPicker";
 import { formatCardIdentifier } from "@/utils/external/restaurant";
+import PapillonHeader, { PapillonHeaderInsetHeight } from "@/components/Global/PapillonHeader";
+import PapillonPicker from "@/components/Global/PapillonPicker";
+import { PapillonHeaderAction } from "@/components/Global/PapillonModernHeader";
 
 const RestaurantCardDetail: Screen<"RestaurantCardDetail"> = ({ route, navigation }) => {
   try {
@@ -67,21 +68,13 @@ const RestaurantCardDetail: Screen<"RestaurantCardDetail"> = ({ route, navigatio
       return unsubscribe;
     }, []);
 
-    React.useLayoutEffect(() => {
-      navigation.setOptions({
-        headerTitle: cardName ?? "Détail de la carte",
-        headerLargeTitleStyle: {
-          color: "transparent",
-        },
-        headerLargeStyle: {
-          backgroundColor: "transparent",
-        },
-        headerStyle: {
-          backgroundColor: Platform.OS === "android" ? theme.colors.card : theme.colors.card + "55",
-        },
-        headerBlurEffect: "regular",
-        headerRight: () => (
+    return (
+      <>
+        <PapillonHeader route={route} navigation={navigation} title={cardName ?? "Détail de la carte"}>
           <PapillonPicker
+            animated
+            direction="right"
+            delay={0}
             data={[
               ...card.theme.links?.map((link) => ({
                 label: link.label,
@@ -120,18 +113,11 @@ const RestaurantCardDetail: Screen<"RestaurantCardDetail"> = ({ route, navigatio
               }
             ]}
           >
-            <TouchableOpacity
-              activeOpacity={0.5}
-            >
-              <MoreHorizontal opacity={0.7} size={24} color={theme.colors.text} />
-            </TouchableOpacity>
+            <PapillonHeaderAction
+              icon={<MoreVertical />}
+            />
           </PapillonPicker>
-        ),
-      });
-    }, [navigation, theme]);
-
-    return (
-      <>
+        </PapillonHeader>
         <ScrollView
           contentInsetAdjustmentBehavior="automatic"
           style={{
@@ -141,6 +127,7 @@ const RestaurantCardDetail: Screen<"RestaurantCardDetail"> = ({ route, navigatio
             padding: 16,
           }}
         >
+          <PapillonHeaderInsetHeight route={route} />
           <PressableScale
             weight="light"
             activeScale={0.95}

--- a/src/views/account/Restaurant/Modals/CardDetail.tsx
+++ b/src/views/account/Restaurant/Modals/CardDetail.tsx
@@ -263,7 +263,7 @@ const RestaurantCardDetail: Screen<"RestaurantCardDetail"> = ({ route, navigatio
             )}
           </View>
 
-          {card?.balance[0].remaining !== null && (
+          {card?.balance[0].remaining !== null && card?.balance[0].remaining !== Infinity && (
             <NativeList inline>
               <NativeItem
                 trailing={

--- a/src/views/account/Restaurant/Modals/CardDetail.tsx
+++ b/src/views/account/Restaurant/Modals/CardDetail.tsx
@@ -263,33 +263,37 @@ const RestaurantCardDetail: Screen<"RestaurantCardDetail"> = ({ route, navigatio
             )}
           </View>
 
-          {card?.balance[0].remaining !== null && card?.balance[0].remaining !== Infinity && (
-            <NativeList inline>
-              <NativeItem
-                trailing={
-                  <NativeText
-                    variant="titleLarge"
-                    style={{
-                      marginRight: 10,
-                      fontFamily: "semibold",
-                      fontSize: 26,
-                      lineHeight: 28,
-                      color: card.balance[0].remaining > 1 ? "#00C853" : "#FF1744",
-                    }}
-                  >
-                    {card.balance[0].remaining.toFixed(0)}
+          {card?.balance[0] &&
+           card?.balance[0].remaining !== null &&
+           card?.balance[0].remaining !== Infinity &&
+            (
+              <NativeList inline>
+                <NativeItem
+                  trailing={
+                    <NativeText
+                      variant="titleLarge"
+                      style={{
+                        marginRight: 10,
+                        fontFamily: "semibold",
+                        fontSize: 26,
+                        lineHeight: 28,
+                        color: card.balance[0].remaining > 1 ? "#00C853" : "#FF1744",
+                      }}
+                    >
+                      {card.balance[0].remaining.toFixed(0)}
+                    </NativeText>
+                  }
+                >
+                  <NativeText variant="title">
+                    Repas restants
                   </NativeText>
-                }
-              >
-                <NativeText variant="title">
-                  Repas restants
-                </NativeText>
-                <NativeText variant="subtitle">
-                  Tarif estimé à {card.balance[0].price?.toFixed(2)} €
-                </NativeText>
-              </NativeItem>
-            </NativeList>
-          )}
+                  <NativeText variant="subtitle">
+                    Tarif estimé à {card.balance[0].price?.toFixed(2)} €
+                  </NativeText>
+                </NativeItem>
+              </NativeList>
+            )
+          }
 
           {card?.history.length > 0 && (
             <NativeList inline>


### PR DESCRIPTION
# ✨ Nouvelle Pull Request

Merci de contribuer à l'amélioration de Papillon !

Tu te poses des questions sur les pull requests (PR) ? Une documentation a spécialement été créée ici => https://gitbook.getpapillon.xyz/organisation/outils-internes/github

## Avant toute chose...

Tu t'assures avoir respecté les points suivants (_en rajoutant un `x` dans les crochets_) :

- [x] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [x] 🗣️ J'utilise le **langage informel** (tutoiement)
- [x] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [x] 📝 J'ai fait **une description des changement effectués** ci-dessous

## Résumé des changements effectués

- Ajout de la possibilité de mettre un titre personnalisé au `PapillonHeader` plutôt que de dépendre sur les `defaultTabs` afin de rendre le `PapillonHeader` plus universel.

- Changement du header natif vers le `PapillonHeader` afin que le menu "Plus" en haut à droite soit consistant avec celui des autres pages et qu'il soit visible sur Android (la taille du header natif empêchait l'affichage convenable du menu).

- Correction de l'affichage des repas restants lorsque l'on est demi-pensionnaire (lorsque tous les prix des repas sont à 0, le nombre de repas restants vaut 'Infinity' du fait de la division par zéro, de ce fait, il est inutile d'afficher le nombre de repas restants dans ce cas)

- Correction du crash de la page lorsque notre compte ne possède pas de solde.

## Capture(s) d'écran (pour rendre le test de ta PR rapide)

![Screenshot_1742752320](https://github.com/user-attachments/assets/465b9c61-0517-45ee-be23-5c136b1f307d)

## Issues liées

- Closes #844 