### PR TITLE
ui: modification des couleurs des interrupteurs pour correspondre au theme choisi

### DIFF
--- a/src/components/Settings/NotificationContainerCard.tsx
+++ b/src/components/Settings/NotificationContainerCard.tsx
@@ -138,10 +138,12 @@ const NotificationContainerCard = ({
         trailing={
           isEnable !== null && isEnable !== undefined ? (
             <Switch
-              trackColor={{
-                false: colors.border,
-                true: colors.primary,
-              }}
+              trackColor={
+                {
+                  false: theme.colors.border, true: theme.colors.primary
+                }
+              }
+              thumbColor={theme.colors.text}
               style={{
                 marginRight: 10,
               }}
@@ -185,9 +187,12 @@ const NotificationContainerCard = ({
               }}
             >
               <Switch
-                trackColor={{
-                  false: colors.border,
-                }}
+                trackColor={
+                  {
+                    false: theme.colors.border, true: theme.colors.primary
+                  }
+                }
+                thumbColor={theme.colors.text}
                 style={{
                   marginRight: 10,
                 }}

--- a/src/components/Settings/NotificationContainerCard.tsx
+++ b/src/components/Settings/NotificationContainerCard.tsx
@@ -140,10 +140,11 @@ const NotificationContainerCard = ({
             <Switch
               trackColor={
                 {
-                  false: theme.colors.border, true: theme.colors.primary
+                  false: colors.border,
+                  true: colors.primary
                 }
               }
-              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
+              thumbColor={theme.dark ? colors.text : colors.background}
               style={{
                 marginRight: 10,
               }}

--- a/src/components/Settings/NotificationContainerCard.tsx
+++ b/src/components/Settings/NotificationContainerCard.tsx
@@ -190,10 +190,11 @@ const NotificationContainerCard = ({
               <Switch
                 trackColor={
                   {
-                    false: theme.colors.border, true: theme.colors.primary
+                    false: colors.border,
+                    true: colors.primary
                   }
                 }
-                thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
+                thumbColor={theme.dark ? colors.text : colors.background}
                 style={{
                   marginRight: 10,
                 }}

--- a/src/components/Settings/NotificationContainerCard.tsx
+++ b/src/components/Settings/NotificationContainerCard.tsx
@@ -143,7 +143,7 @@ const NotificationContainerCard = ({
                   false: theme.colors.border, true: theme.colors.primary
                 }
               }
-              thumbColor={theme.colors.text}
+              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               style={{
                 marginRight: 10,
               }}
@@ -192,7 +192,7 @@ const NotificationContainerCard = ({
                     false: theme.colors.border, true: theme.colors.primary
                   }
                 }
-                thumbColor={theme.colors.text}
+                thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
                 style={{
                   marginRight: 10,
                 }}

--- a/src/views/settings/SettingsAccessibility.tsx
+++ b/src/views/settings/SettingsAccessibility.tsx
@@ -15,7 +15,6 @@ import PapillonCheckbox from "@/components/Global/PapillonCheckbox";
 import { useThemeSoundHaptics } from "@/hooks/Theme_Sound_Haptics";
 import { Switch } from "react-native-gesture-handler";
 import AccessibilityContainerCard from "@/components/Settings/AccesilityContainerCard";
-import { th } from "date-fns/locale";
 
 const SettingsAccessibility: Screen<"SettingsAccessibility"> = () => {
   const theme = useTheme();

--- a/src/views/settings/SettingsAccessibility.tsx
+++ b/src/views/settings/SettingsAccessibility.tsx
@@ -101,7 +101,7 @@ const SettingsAccessibility: Screen<"SettingsAccessibility"> = () => {
                 false: theme.colors.border,
                 true: theme.colors.primary,
               }}
-              thumbColor={theme.colors.text}
+              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               value={enableSon}
               onValueChange={(value) => setEnableSon(value)}
             />
@@ -129,7 +129,7 @@ const SettingsAccessibility: Screen<"SettingsAccessibility"> = () => {
                 false: theme.colors.border,
                 true: theme.colors.primary,
               }}
-              thumbColor={theme.colors.text}
+              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               value={enableHaptics}
               onValueChange={(value) => setEnableHaptics(value)}
             />

--- a/src/views/settings/SettingsAccessibility.tsx
+++ b/src/views/settings/SettingsAccessibility.tsx
@@ -15,6 +15,7 @@ import PapillonCheckbox from "@/components/Global/PapillonCheckbox";
 import { useThemeSoundHaptics } from "@/hooks/Theme_Sound_Haptics";
 import { Switch } from "react-native-gesture-handler";
 import AccessibilityContainerCard from "@/components/Settings/AccesilityContainerCard";
+import { th } from "date-fns/locale";
 
 const SettingsAccessibility: Screen<"SettingsAccessibility"> = () => {
   const theme = useTheme();
@@ -101,6 +102,7 @@ const SettingsAccessibility: Screen<"SettingsAccessibility"> = () => {
                 false: theme.colors.border,
                 true: theme.colors.primary,
               }}
+              thumbColor={theme.colors.text}
               value={enableSon}
               onValueChange={(value) => setEnableSon(value)}
             />
@@ -128,6 +130,7 @@ const SettingsAccessibility: Screen<"SettingsAccessibility"> = () => {
                 false: theme.colors.border,
                 true: theme.colors.primary,
               }}
+              thumbColor={theme.colors.text}
               value={enableHaptics}
               onValueChange={(value) => setEnableHaptics(value)}
             />

--- a/src/views/settings/SettingsMagic.tsx
+++ b/src/views/settings/SettingsMagic.tsx
@@ -31,10 +31,10 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
             <Switch
               trackColor={
                 {
-                  false: theme.colors.border, true: theme.colors.primary
+                  false: colors.border, true: colors.primary
                 }
               }
-              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
+              thumbColor={theme.dark ? colors.text : colors.background}
               value={account?.personalization?.MagicNews ?? false}
               onValueChange={(value) => mutateProperty("personalization", { MagicNews: value })}
             />
@@ -62,10 +62,10 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
             <Switch
               trackColor={
                 {
-                  false: theme.colors.border, true: theme.colors.primary
+                  false: colors.border, true: colors.primary
                 }
               }
-              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
+              thumbColor={theme.dark ? colors.text : colors.background}
               value={account?.personalization?.MagicHomeworks ?? false}
               onValueChange={(value) => mutateProperty("personalization", { MagicHomeworks: value })}
             />

--- a/src/views/settings/SettingsMagic.tsx
+++ b/src/views/settings/SettingsMagic.tsx
@@ -29,6 +29,12 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
         <NativeItem
           trailing={
             <Switch
+              trackColor={
+                {
+                  false: theme.colors.border, true: theme.colors.primary
+                }
+              }
+              thumbColor={theme.colors.text}
               value={account?.personalization?.MagicNews ?? false}
               onValueChange={(value) => mutateProperty("personalization", { MagicNews: value })}
             />
@@ -54,6 +60,12 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
         <NativeItem
           trailing={
             <Switch
+              trackColor={
+                {
+                  false: theme.colors.border, true: theme.colors.primary
+                }
+              }
+              thumbColor={theme.colors.text}
               value={account?.personalization?.MagicHomeworks ?? false}
               onValueChange={(value) => mutateProperty("personalization", { MagicHomeworks: value })}
             />

--- a/src/views/settings/SettingsMagic.tsx
+++ b/src/views/settings/SettingsMagic.tsx
@@ -34,7 +34,7 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
                   false: theme.colors.border, true: theme.colors.primary
                 }
               }
-              thumbColor={theme.colors.text}
+              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               value={account?.personalization?.MagicNews ?? false}
               onValueChange={(value) => mutateProperty("personalization", { MagicNews: value })}
             />
@@ -65,7 +65,7 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
                   false: theme.colors.border, true: theme.colors.primary
                 }
               }
-              thumbColor={theme.colors.text}
+              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               value={account?.personalization?.MagicHomeworks ?? false}
               onValueChange={(value) => mutateProperty("personalization", { MagicHomeworks: value })}
             />

--- a/src/views/settings/SettingsMagic.tsx
+++ b/src/views/settings/SettingsMagic.tsx
@@ -63,7 +63,8 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
             <Switch
               trackColor={
                 {
-                  false: colors.border, true: colors.primary
+                  false: colors.border,
+                  true: colors.primary
                 }
               }
               thumbColor={theme.dark ? colors.text : colors.background}

--- a/src/views/settings/SettingsMagic.tsx
+++ b/src/views/settings/SettingsMagic.tsx
@@ -31,7 +31,8 @@ const SettingsMagic: Screen<"SettingsMagic"> = ({ navigation }) => {
             <Switch
               trackColor={
                 {
-                  false: colors.border, true: colors.primary
+                  false: colors.border,
+                  true: colors.primary
                 }
               }
               thumbColor={theme.dark ? colors.text : colors.background}

--- a/src/views/settings/SettingsMultiService.tsx
+++ b/src/views/settings/SettingsMultiService.tsx
@@ -152,6 +152,12 @@ const SettingsMultiService: Screen<"SettingsMultiService"> = ({ navigation }) =>
         <NativeItem
           trailing={
             <Switch
+              trackColor={
+                {
+                  false: theme.colors.border, true: theme.colors.primary
+                }
+              }
+              thumbColor={theme.colors.text}
               value={multiServiceEnabled ?? false}
               onValueChange={() => {
                 if (multiServiceEnabled) {

--- a/src/views/settings/SettingsMultiService.tsx
+++ b/src/views/settings/SettingsMultiService.tsx
@@ -154,7 +154,8 @@ const SettingsMultiService: Screen<"SettingsMultiService"> = ({ navigation }) =>
             <Switch
               trackColor={
                 {
-                  false: theme.colors.border, true: theme.colors.primary
+                  false: theme.colors.border,
+                  true: theme.colors.primary
                 }
               }
               thumbColor={theme.dark ? theme.colors.text : theme.colors.background}

--- a/src/views/settings/SettingsMultiService.tsx
+++ b/src/views/settings/SettingsMultiService.tsx
@@ -157,7 +157,7 @@ const SettingsMultiService: Screen<"SettingsMultiService"> = ({ navigation }) =>
                   false: theme.colors.border, true: theme.colors.primary
                 }
               }
-              thumbColor={theme.colors.text}
+              thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               value={multiServiceEnabled ?? false}
               onValueChange={() => {
                 if (multiServiceEnabled) {

--- a/src/views/settings/SettingsNotifications.tsx
+++ b/src/views/settings/SettingsNotifications.tsx
@@ -176,10 +176,12 @@ const SettingsNotifications: Screen<"SettingsNotifications"> = ({
                 entering={anim2Papillon(FadeInDown).delay(70 * index)}
                 trailing={
                   <Switch
-                    trackColor={{
-                      false: colors.border,
-                      true: colors.primary,
-                    }}
+                    trackColor={
+                      {
+                        false: theme.colors.border, true: theme.colors.primary
+                      }
+                    }
+                    thumbColor={theme.colors.text}
                     value={
                       account.personalization.notifications?.[
                         notification.personalizationValue as keyof typeof notifications

--- a/src/views/settings/SettingsNotifications.tsx
+++ b/src/views/settings/SettingsNotifications.tsx
@@ -178,10 +178,11 @@ const SettingsNotifications: Screen<"SettingsNotifications"> = ({
                   <Switch
                     trackColor={
                       {
-                        false: theme.colors.border, true: theme.colors.primary
+                        false: colors.border,
+                        true: theme.colors.primary
                       }
                     }
-                    thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
+                    thumbColor={theme.dark ? colors.text : colors.background}
                     value={
                       account.personalization.notifications?.[
                         notification.personalizationValue as keyof typeof notifications

--- a/src/views/settings/SettingsNotifications.tsx
+++ b/src/views/settings/SettingsNotifications.tsx
@@ -181,7 +181,7 @@ const SettingsNotifications: Screen<"SettingsNotifications"> = ({
                         false: theme.colors.border, true: theme.colors.primary
                       }
                     }
-                    thumbColor={theme.colors.text}
+                    thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
                     value={
                       account.personalization.notifications?.[
                         notification.personalizationValue as keyof typeof notifications

--- a/src/views/settings/SettingsProfile.tsx
+++ b/src/views/settings/SettingsProfile.tsx
@@ -305,8 +305,12 @@ const SettingsProfile: Screen<"SettingsProfile"> = ({ navigation }) => {
               <Switch
                 value={!hideNameOnHomeScreen}
                 onValueChange={() => setHideNameOnHomeScreen(!hideNameOnHomeScreen)}
-                trackColor={{false: theme.colors.border, true: theme.colors.primary}}
-                thumbColor={theme.colors.background}
+                trackColor={
+                  {
+                    false: theme.colors.border, true: theme.colors.primary
+                  }
+                }
+                thumbColor={theme.colors.text}
               />
             }
           >
@@ -326,8 +330,12 @@ const SettingsProfile: Screen<"SettingsProfile"> = ({ navigation }) => {
               <Switch
                 value={!hideProfilePicOnHomeScreen}
                 onValueChange={() => setHideProfilePicOnHomeScreen(!hideProfilePicOnHomeScreen)}
-                trackColor={{false: theme.colors.border, true: theme.colors.primary}}
-                thumbColor={theme.colors.background}
+                trackColor={
+                  {
+                    false: theme.colors.border, true: theme.colors.primary
+                  }
+                }
+                thumbColor={theme.colors.text}
               />
             }
           >

--- a/src/views/settings/SettingsProfile.tsx
+++ b/src/views/settings/SettingsProfile.tsx
@@ -310,7 +310,7 @@ const SettingsProfile: Screen<"SettingsProfile"> = ({ navigation }) => {
                     false: theme.colors.border, true: theme.colors.primary
                   }
                 }
-                thumbColor={theme.colors.text}
+                thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               />
             }
           >
@@ -335,7 +335,7 @@ const SettingsProfile: Screen<"SettingsProfile"> = ({ navigation }) => {
                     false: theme.colors.border, true: theme.colors.primary
                   }
                 }
-                thumbColor={theme.colors.text}
+                thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
               />
             }
           >

--- a/src/views/settings/SettingsProfile.tsx
+++ b/src/views/settings/SettingsProfile.tsx
@@ -333,7 +333,8 @@ const SettingsProfile: Screen<"SettingsProfile"> = ({ navigation }) => {
                 onValueChange={() => setHideProfilePicOnHomeScreen(!hideProfilePicOnHomeScreen)}
                 trackColor={
                   {
-                    false: theme.colors.border, true: theme.colors.primary
+                    false: theme.colors.border,
+                    true: theme.colors.primary
                   }
                 }
                 thumbColor={theme.dark ? theme.colors.text : theme.colors.background}

--- a/src/views/settings/SettingsProfile.tsx
+++ b/src/views/settings/SettingsProfile.tsx
@@ -307,7 +307,8 @@ const SettingsProfile: Screen<"SettingsProfile"> = ({ navigation }) => {
                 onValueChange={() => setHideNameOnHomeScreen(!hideNameOnHomeScreen)}
                 trackColor={
                   {
-                    false: theme.colors.border, true: theme.colors.primary
+                    false: theme.colors.border,
+                    true: theme.colors.primary
                   }
                 }
                 thumbColor={theme.dark ? theme.colors.text : theme.colors.background}

--- a/src/views/settings/SettingsTabs.tsx
+++ b/src/views/settings/SettingsTabs.tsx
@@ -512,7 +512,8 @@ const SettingsTabs = () => {
                 <Switch
                   trackColor={
                     {
-                      false: theme.colors.border, true: theme.colors.primary
+                      false: theme.colors.border,
+                      true: theme.colors.primary
                     }
                   }
                   thumbColor={theme.dark ? theme.colors.text : theme.colors.background}

--- a/src/views/settings/SettingsTabs.tsx
+++ b/src/views/settings/SettingsTabs.tsx
@@ -540,7 +540,8 @@ const SettingsTabs = () => {
                 <Switch
                   trackColor={
                     {
-                      false: theme.colors.border, true: theme.colors.primary
+                      false: theme.colors.border,
+                      true: theme.colors.primary
                     }
                   }
                   thumbColor={theme.dark ? theme.colors.text : theme.colors.background}

--- a/src/views/settings/SettingsTabs.tsx
+++ b/src/views/settings/SettingsTabs.tsx
@@ -510,6 +510,12 @@ const SettingsTabs = () => {
               icon={<Captions />}
               trailing={
                 <Switch
+                  trackColor={
+                    {
+                      false: theme.colors.border, true: theme.colors.primary
+                    }
+                  }
+                  thumbColor={theme.colors.text}
                   value={!hideTabTitles}
                   onValueChange={() => {
                     setHideTabTitles(!hideTabTitles);
@@ -531,6 +537,12 @@ const SettingsTabs = () => {
               icon={<SendToBack />}
               trailing={
                 <Switch
+                  trackColor={
+                    {
+                      false: theme.colors.border, true: theme.colors.primary
+                    }
+                  }
+                  thumbColor={theme.colors.text}
                   value={showTabBackground}
                   onValueChange={() => {
                     setShowTabBackground(!showTabBackground);

--- a/src/views/settings/SettingsTabs.tsx
+++ b/src/views/settings/SettingsTabs.tsx
@@ -515,7 +515,7 @@ const SettingsTabs = () => {
                       false: theme.colors.border, true: theme.colors.primary
                     }
                   }
-                  thumbColor={theme.colors.text}
+                  thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
                   value={!hideTabTitles}
                   onValueChange={() => {
                     setHideTabTitles(!hideTabTitles);
@@ -542,7 +542,7 @@ const SettingsTabs = () => {
                       false: theme.colors.border, true: theme.colors.primary
                     }
                   }
-                  thumbColor={theme.colors.text}
+                  thumbColor={theme.dark ? theme.colors.text : theme.colors.background}
                   value={showTabBackground}
                   onValueChange={() => {
                     setShowTabBackground(!showTabBackground);


### PR DESCRIPTION
# ✨ Nouvelle Pull Request

Merci de contribuer à l'amélioration de Papillon !

Tu te poses des questions sur les pull requests (PR) ? Une documentation a spécialement été créée ici => https://gitbook.getpapillon.xyz/organisation/outils-internes/github

## Avant toute chose...

Tu t'assures avoir respecté les points suivants (_en rajoutant un `x` dans les crochets_) :

- [x] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [x] 🗣️ J'utilise le **langage informel** (tutoiement)
- [x] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [x] 📝 J'ai fait **une description des changement effectués** ci-dessous

## Résumé des changements effectués

La PR est une modification de la couleur des interrupteurs afin qu'ils harmonisent avec le jeu de couleurs.
Pour faire ça, j'ai ajouté un opérateur ternaire dans la thumbColor qui ajuste sa couleur pour être en cohérence avec les deux modes d'affichage et modifié la trackColor pour qu'elle prenne la couleur primaire du thème lorsque l'interrupteur est activé.

## Capture(s) d'écran (pour rendre le test de ta PR rapide)

Les anciens interrupteurs:

![old_switch_comparaison_sombre_et_clair](https://github.com/user-attachments/assets/58e93f24-1ae3-41f4-b8ba-a2981e4a30c8)


Comparées aux nouveaux:

![nv_switch_comparaison_sombre_et_clair](https://github.com/user-attachments/assets/e083e80b-a349-43d7-a2d7-6088ce303548)
