### PR TITLE
fix : stop checking Pronote auth when having another account type.

### DIFF
--- a/src/views/account/Chat/Messages.tsx
+++ b/src/views/account/Chat/Messages.tsx
@@ -63,8 +63,12 @@ const Discussions: Screen<"Discussions"> = ({ navigation, route }) => {
 
   const supported = account.service === AccountService.Pronote || account.service === AccountService.EcoleDirecte;
 
-  // @ts-expect-error
-  const enabled = supported && account.instance?.user.authorizations.tabs.includes(TabLocation.Discussions);
+  const enabled = supported &&
+  (account.service === AccountService.Pronote ?
+    account.instance?.user.authorizations.tabs.includes(TabLocation.Discussions)
+    :
+    true
+  );
 
   useLayoutEffect(() => {
     navigation.setOptions({


### PR DESCRIPTION
- [x] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [x] 🗣️ J'utilise le **langage informel** (tutoiement)
- [x] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [x] 📝 J'ai fait **une description des changement effectués** ci-dessous

## Résumé des changements effectués

Fix : lors de la vérification de l'activation des messages, quel que soit le service utilisé, un test d'authentification Pronote était effectué.
