### PR TITLE
fix(SettingsDevLogs): re-render en continu

### DIFF
--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -125,6 +125,7 @@ export interface Log {
   date: string;
   from?: string;
   message: string;
+  formattedDate?: string;
 }
 
 async function get_logs (): Promise<Log[]> {

--- a/src/views/account/Grades/Subject/Subject.tsx
+++ b/src/views/account/Grades/Subject/Subject.tsx
@@ -112,7 +112,9 @@ const Subject: React.FC<SubjectProps> = ({
                 textTransform: "uppercase",
               }}
             >
-              {sortings[sorting]?.label}
+              {typeof sortings[sorting] === "string"
+                ? sortings[sorting]
+                : sortings[sorting]?.label}
             </NativeText>
             {isLoading && (
               <PapillonSpinner

--- a/src/views/account/Grades/Subject/SubjectList.tsx
+++ b/src/views/account/Grades/Subject/SubjectList.tsx
@@ -20,6 +20,11 @@ interface SubjectItemProps {
   index?: number;
 }
 
+interface renderGradeItemProps {
+  item: Grade;
+  index: number;
+}
+
 const SubjectItem: React.FC<SubjectItemProps> = ({
   subject,
   allGrades,
@@ -41,7 +46,7 @@ const SubjectItem: React.FC<SubjectItemProps> = ({
     return null;
   }
 
-  const renderGradeItem = useCallback(({ item, index }) => (
+  const renderGradeItem = useCallback(({ item, index }: renderGradeItemProps) => (
     <SubjectGradeItem
       subject={subject}
       grade={item}
@@ -50,7 +55,7 @@ const SubjectItem: React.FC<SubjectItemProps> = ({
     />
   ), [subject, allGrades, navigation]);
 
-  const keyExtractor = useCallback((item) => item.id, []);
+  const keyExtractor = useCallback((item: Grade) => item.id, []);
 
   return (
     <NativeList

--- a/src/views/settings/SettingsDevLogs.tsx
+++ b/src/views/settings/SettingsDevLogs.tsx
@@ -53,9 +53,18 @@ const SettingsDevLogs: Screen<"SettingsDevLogs"> = () => {
   useEffect(() => {
     get_logs().then((logs) => {
       setLogs(
-        logs.sort(
-          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-        )
+        logs
+          .sort(
+            (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+          )
+          .map((log) => ({
+            ...log,
+            formattedDate: formatDistanceToNow(new Date(log.date), {
+              addSuffix: true,
+              includeSeconds: true,
+              locale: fr,
+            }),
+          }))
       );
       setLoading(false);
     });
@@ -212,11 +221,7 @@ const SettingsDevLogs: Screen<"SettingsDevLogs"> = () => {
                 >
                   <NativeText variant="title">{log.message}</NativeText>
                   <NativeText variant="subtitle">
-                    {formatDistanceToNow(log.date, {
-                      addSuffix: true,
-                      includeSeconds: true,
-                      locale: fr,
-                    })}
+                    {log.formattedDate ?? log.date}
                   </NativeText>
                   <NativeText variant="subtitle">{log.from}</NativeText>
                 </NativeItem>


### PR DESCRIPTION
# ✨ Nouvelle Pull Request

Merci de contribuer à l'amélioration de Papillon !

Tu te poses des questions sur les pull requests (PR) ? Une documentation a spécialement été créée ici => https://gitbook.getpapillon.xyz/organisation/outils-internes/github

## Avant toute chose...

Tu t'assures avoir respecté les points suivants (_en rajoutant un `x` dans les crochets_) :

- [x] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [x] 🗣️ J'utilise le **langage informel** (tutoiement)
- [x] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [x] 📝 J'ai fait **une description des changement effectués** ci-dessous

## Résumé des changements effectués

Le mélange de `showAlert` et `formattedDateToNow` provoquait un re-render en continu, bloquant dès fois la page !
Désormais, `formattedDateToNow` est toujours utilisé mais lors de l'initialisation des logs, donc ne provoquant aucun re-render

## Capture(s) d'écran (pour rendre le test de ta PR rapide)

undefined

## Issue(s) en rapport

> [!NOTE]
>
> Cette section te permet de référencer des issues en lien avec ta PR. Pour que les issues soient fermées automatiquement au merge, utilise les "[closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)" de Github (exemples ci-dessous).

- Closed #905

_S'il y en a plusieurs, continuer à les lister_

- Closed #(_le numéro de l'issue_)
