### PR TITLE
Fix pronote token expiration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useAccounts, useCurrentAccount } from "@/stores/account";
 import { AccountService } from "@/stores/account/types";
 import { log } from "@/utils/logger/logger";
+import { useAlert } from "@/providers/AlertProvider";
+import { BadgeX } from "lucide-react-native";
 import { isExpoGo } from "@/utils/native/expoGoAlert";
 import { atobPolyfill, btoaPolyfill } from "js-base64";
 import { registerBackgroundTasks } from "@/background/BackgroundTasks";
@@ -32,6 +34,7 @@ export default function App () {
   const currentAccount = useCurrentAccount((store) => store.account);
   const switchTo = useCurrentAccount((store) => store.switchTo);
   const accounts = useAccounts((store) => store.accounts).filter(account => !account.isExternal);
+  const { showAlert } = useAlert();
 
   const defined = useFlagsStore(state => state.defined);
   const [fontsLoaded] = useFonts(getToLoadFonts(defined));
@@ -78,6 +81,13 @@ export default function App () {
         if (account.localID === currentAccount.localID) {
           await switchTo(account).catch((error) => {
             log(`Error during switchTo: ${error}`, "RefreshToken");
+            if (account.service === AccountService.Pronote) {
+              showAlert({
+                title: "Connexion expirée",
+                message: "Ton compte PRONOTE a expiré, reconnecte-toi.",
+                icon: <BadgeX />,
+              });
+            }
           });
           break;
         }

--- a/src/services/pronote/reload-instance.ts
+++ b/src/services/pronote/reload-instance.ts
@@ -4,14 +4,33 @@ import { Reconnected } from "../reload-account";
 
 export const reloadInstance = async (authentication: PronoteAccount["authentication"]): Promise<Reconnected<PronoteAccount>> => {
   const session = pronote.createSessionHandle();
-  const refresh = await pronote.loginToken(session, authentication);
+  const tokens = [authentication.token, ...(authentication.oldTokens || [])];
+  let refresh: pronote.RefreshInformation | undefined;
+  let lastError: unknown = null;
+
+  for (const token of tokens) {
+    try {
+      refresh = await pronote.loginToken(session, { ...authentication, token });
+      break;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  if (!refresh) {
+    throw lastError || pronote.AuthenticateError;
+  }
+
   pronote.startPresenceInterval(session);
+
+  const uniqueTokens = Array.from(new Set([refresh.token, ...tokens]));
 
   return {
     instance: session,
     authentication: {
       ...authentication,
-      ...refresh
+      ...refresh,
+      oldTokens: uniqueTokens
     }
   };
 };

--- a/src/stores/account/types.ts
+++ b/src/stores/account/types.ts
@@ -161,6 +161,7 @@ export interface PronoteAccount extends BaseAccount {
 
   authentication: pronote.RefreshInformation & {
     deviceUUID: string;
+    oldTokens?: string[];
   };
   identityProvider?: undefined;
   providers: string[];

--- a/src/views/login/pronote/PronoteCredentials.tsx
+++ b/src/views/login/pronote/PronoteCredentials.tsx
@@ -65,7 +65,7 @@ const PronoteCredentials: Screen<"PronoteCredentials"> = ({ route, navigation })
           last: extract_pronote_name(name).familyName
         },
 
-        authentication: { ...refresh, deviceUUID: accountID },
+        authentication: { ...refresh, deviceUUID: accountID, oldTokens: [refresh.token] },
         personalization: await defaultPersonalization(session),
 
         identity: {},

--- a/src/views/login/pronote/PronoteQRCode.tsx
+++ b/src/views/login/pronote/PronoteQRCode.tsx
@@ -124,7 +124,7 @@ const PronoteQRCode: Screen<"PronoteQRCode"> = ({ navigation }) => {
           last: extract_pronote_name(name).familyName
         },
 
-        authentication: { ...refresh, deviceUUID: accountID },
+        authentication: { ...refresh, deviceUUID: accountID, oldTokens: [refresh.token] },
         personalization: await defaultPersonalization(session),
 
         identity: {},

--- a/src/views/login/pronote/PronoteV6Import.tsx
+++ b/src/views/login/pronote/PronoteV6Import.tsx
@@ -72,7 +72,7 @@ const PronoteV6Import: Screen<"PronoteV6Import"> = ({ route, navigation }) => {
           last: extract_pronote_name(name).familyName
         },
 
-        authentication: { ...refresh, deviceUUID: data.deviceUUID },
+        authentication: { ...refresh, deviceUUID: data.deviceUUID, oldTokens: [refresh.token] },
         personalization: await defaultPersonalization(session),
 
         identity: {},

--- a/src/views/login/pronote/PronoteWebview.tsx
+++ b/src/views/login/pronote/PronoteWebview.tsx
@@ -312,7 +312,7 @@ const PronoteWebview: Screen<"PronoteWebview"> = ({ route, navigation }) => {
                     last: extract_pronote_name(name).familyName,
                   },
 
-                  authentication: { ...refresh, deviceUUID },
+                  authentication: { ...refresh, deviceUUID, oldTokens: [refresh.token] },
                   personalization: await defaultPersonalization(session),
 
                   identity: {},


### PR DESCRIPTION
## Summary
- store previous Pronote tokens in account auth
- retry all known tokens when reloading Pronote session
- prompt user to reconnect when automatic refresh fails

## Testing
- `npm run lint` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68406cae8dc083259448fbc538574842