### PR TITLE
feat : Show "Conseil de classe" message in red in the timetable

### DIFF
--- a/src/services/pronote/timetable.ts
+++ b/src/services/pronote/timetable.ts
@@ -23,7 +23,7 @@ const decodeTimetableClass = (c: pronote.TimetableClassLesson | pronote.Timetabl
       room: c.classrooms.join(", ") || void 0,
       teacher: c.teacherNames?.join(", ") ?? void 0,
       group: c.groupNames.join(", ") || void 0,
-      status: c.status === "Cours annulé" || c.status === "Prof. absent" || c.status === "Classe absente" || c.status === "Prof./pers. absent" || c.status === "Sortie pédagogique" ? TimetableClassStatus.CANCELED : c.test ? TimetableClassStatus.TEST : void 0,
+      status: c.status === "Cours annulé" || c.status === "Prof. absent" || c.status === "Classe absente" || c.status === "Prof./pers. absent" || c.status === "Sortie pédagogique" || c.status === "Conseil de classe" ? TimetableClassStatus.CANCELED : c.test ? TimetableClassStatus.TEST : void 0,
       statusText: c.test ? "Devoir Surveillé" : c.status,
       ressourceID: c.lessonResourceID ?? void 0,
       ...base


### PR DESCRIPTION
# ✨ Nouvelle Pull Request

Merci de contribuer à l'amélioration de Papillon !

Tu te poses des questions sur les pull requests (PR) ? Une documentation a spécialement été créée ici => https://gitbook.getpapillon.xyz/organisation/outils-internes/github

## Avant toute chose...

Tu t'assures avoir respecté les points suivants (_en rajoutant un `x` dans les crochets_) :

- [x] 📲 J'ai testé l'application via Expo Go et/ou Build et **elle fonctionne correctement**
- [x] 🗣️ J'utilise le **langage informel** (tutoiement)
- [x] 📃 Cette PR [**n'est pas un duplicata**](https://github.com/PapillonApp/Papillon/pulls) et **est prête à être review et merge**
- [x] ❌ Je n'ai pas fait **d'erreurs TypeScript et ESLint** dans le code
- [x] 📝 J'ai fait **une description des changement effectués** ci-dessous

## Résumé des changements effectués

-Modification mineure du code qui permet d'afficher le status "Conseil de classe" en rouge car il indique que le cours est annulé. ( Demandé par un utilisateur sur le Discord).

## Capture(s) d'écran (pour rendre le test de ta PR rapide)
 
### Avant : 

![Simulator Screenshot - iPhone 16 Plus - 2025-06-11 at 18 11 30](https://github.com/user-attachments/assets/da13775c-0cc4-435f-8561-ff7c8d249b13)

### Après : 

![Simulator Screenshot - iPhone 16 Plus - 2025-06-11 at 18 09 58](https://github.com/user-attachments/assets/fa62a443-69ed-42c8-8fac-f37b64d8519a)

